### PR TITLE
ENV['http_proxy'] can be an empty string

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -438,7 +438,7 @@ class HTTPClient
   #
   # Calling this method resets all existing sessions.
   def proxy=(proxy)
-    if proxy.nil?
+    if proxy.nil? || proxy.empty?
       @proxy = nil
       @proxy_auth.reset_challenge
     else

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -234,6 +234,15 @@ class TestHTTPClient < Test::Unit::TestCase
     end
   end
 
+  def test_empty_proxy_env
+    setup_proxyserver
+    escape_env do
+      ENV['http_proxy'] = ""
+      client = HTTPClient.new
+      assert_equal(nil, client.proxy)
+    end
+  end
+
   def test_noproxy_for_localhost
     @proxyio.string = ""
     @client.proxy = @proxyurl


### PR DESCRIPTION
Just treat it the same as if it was nil/unset, rather than raising "unsupported proxy "
