### PR TITLE
disable Transfer-Encoding: chuncked when IO respond to :read

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -728,9 +728,9 @@ class HTTPClient
   # a HTTP request message body.
   #
   # When you pass an IO as a body, HTTPClient sends it as a HTTP request with
-  # chunked encoding (Transfer-Encoding: chunked in HTTP header).  Bear in mind
-  # that some server application does not support chunked request.  At least
-  # cgi.rb does not support it.
+  # chunked encoding (Transfer-Encoding: chunked in HTTP header) if IO does not
+  # respond to :read. Bear in mind that some server application does not support
+  # chunked request.  At least cgi.rb does not support it.
   def request(method, uri, *args, &block)
     query, body, header, follow_redirect = keyword_argument(args, :query, :body, :header, :follow_redirect)
     if [:post, :put].include?(method)

--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -440,20 +440,26 @@ module HTTP
       # If no dev (the second argument) given, this method returns a dumped
       # String.
       def dump(header = '', dev = '')
+        file_block = Proc.new { |body|
+          buf = ''
+          reset_pos(body)
+          while !body.read(@chunk_size, buf).nil?
+            dev << buf
+          end
+          body.rewind
+        }
         if @body.is_a?(Parts)
           dev << header
-          buf = ''
           @body.parts.each do |part|
             if Message.file?(part)
-              reset_pos(part)
-              while !part.read(@chunk_size, buf).nil?
-                dev << buf
-              end
-              part.rewind
+              file_block.call(part)
             else
-              dev << part
+              dev << body
             end
           end
+        elsif Message.file?(@body)
+          dev << header
+          file_block.call(@body)
         elsif @body
           dev << header + @body
         else
@@ -498,11 +504,11 @@ module HTTP
 
       def set_content(body, boundary = nil)
         if body.respond_to?(:read)
-          # uses Transfer-Encoding: chunked.  bear in mind that server may not
-          # support it.  at least ruby's CGI doesn't.
+          # uses Transfer-Encoding: chunked if body does not respond to :size.
+          # bear in mind that server may not support it. at least ruby's CGI doesn't.
           @body = body
           remember_pos(@body)
-          @size = nil
+          @size = body.respond_to?(:size) ? body.size : nil
         elsif boundary and Message.multiparam_query?(body)
           @body = build_query_multipart_str(body, boundary)
           @size = @body.size


### PR DESCRIPTION
1. There is no need to send query with Transfer-Encoding: chuncked when
   IO respond to :size.
2. Lighttpd does not support PUT, POST with Transfer-Encoding: chuncked.
   You will see that the lighty respond with 200 OK, but there is a file
   whose size is zero...

Currently, HTTPClient::Session#query assumes that _all_ write are finished in @send_timeout
not each write.  so timeout occurs certaitly when you send a very large file in spite of being 
processing each write. I also want to fix this issue but I have no idea :-(
