### PR TITLE
(resubmit) disable Transfer-Encoding: chuncked when IO respond to :read

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -728,9 +728,9 @@ class HTTPClient
   # a HTTP request message body.
   #
   # When you pass an IO as a body, HTTPClient sends it as a HTTP request with
-  # chunked encoding (Transfer-Encoding: chunked in HTTP header).  Bear in mind
-  # that some server application does not support chunked request.  At least
-  # cgi.rb does not support it.
+  # chunked encoding (Transfer-Encoding: chunked in HTTP header) if IO does not
+  # respond to :read. Bear in mind that some server application does not support
+  # chunked request.  At least cgi.rb does not support it.
   def request(method, uri, *args, &block)
     query, body, header, follow_redirect = keyword_argument(args, :query, :body, :header, :follow_redirect)
     if [:post, :put].include?(method)


### PR DESCRIPTION
1. There is no need to send query with Transfer-Encoding: chuncked when
   IO respond to :size.
2. Lighttpd does not support PUT, POST with Transfer-Encoding: chuncked.
   You will see that the lighty respond with 200 OK, but there is a file
   whose size is zero...

Currently, HTTPClient::Session#query assumes that _all_ write are finished in @send_timeout
not each write.  so timeout occurs certainly when you send a very large file in spite of being 
processing each write. I also want to fix this issue but I have no idea :-(
