### PR TITLE
Include README.txt to the gem installation

### DIFF
--- a/httpclient.gemspec
+++ b/httpclient.gemspec
@@ -8,6 +8,6 @@ Gem::Specification.new { |s|
   s.homepage = "http://github.com/nahi/httpclient"
   s.platform = Gem::Platform::RUBY
   s.summary = "gives something like the functionality of libwww-perl (LWP) in Ruby"
-  s.files = Dir.glob("{lib,sample,test}/**/*")
+  s.files = Dir.glob('{lib,sample,test}/**/*') + ['README.txt']
   s.require_path = "lib"
 }


### PR DESCRIPTION
I updated the gem to the newest one today, and found that there's no README included.
It might be nicer to ship the gem with README so that the users don't have to visit the repo just for reading the documentation.
