### PR TITLE
Require open-uri only on ruby 1.9, since it is not needed on 1.8.

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -7,7 +7,9 @@
 
 
 require 'time'
-require 'open-uri' # for encoding
+if defined?(Encoding::ASCII_8BIT)
+  require 'open-uri' # for encoding
+end
 
 
 # A namespace module for HTTP Message definitions used by HTTPClient.


### PR DESCRIPTION
open-uri modifies the behavior of global open(), which is undesirable
in some situations. Do not require it unless it is going to be used.

In my application I have an overlay open-uri.rb that raises an exception when someone requires it, such that it is not possible to open network urls by accident via open() calls.
