### PR TITLE
Add workaround for JRuby issue on Windows (JRUBY-6136)

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -590,14 +590,14 @@ module HTTP
           if Message.file?(part)
             @as_stream = true
             @body << part
-            if part.respond_to?(:size)
+            if part.respond_to?(:lstat)
+              @size += part.lstat.size
+            elsif part.respond_to?(:size)
               if sz = part.size
                 @size += sz
               else
                 @size = nil
               end
-            elsif part.respond_to?(:lstat)
-              @size += part.lstat.size
             else
               # use chunked upload
               @size = nil

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -649,6 +649,19 @@ EOS
     end
   end
 
+  def test_post_with_file_without_size
+    STDOUT.sync = true
+    File.open(__FILE__) do |file|
+      def file.size
+        # Simulates some strange Windows behaviour
+        raise SystemCallError.new "Unknown Error (20047)"
+      end
+      assert_nothing_raised do
+        @client.post(serverurl + 'servlet', {1=>2, 3=>file})
+      end
+    end
+  end
+
   def test_post_with_io # streaming, but not chunked
     myio = StringIO.new("X" * (HTTP::Message::Body::DEFAULT_CHUNK_SIZE + 1))
     def myio.read(*args)


### PR DESCRIPTION
On Windows, calling File#size fails with an Unknown error (20047) - see http://jira.codehaus.org/browse/JRUBY-6136 for further information.

This workaround uses File#lstat instead of File#size.
