### PR TITLE
Accept an array of strings (and IO-likes) as a query value.

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -821,13 +821,36 @@ module HTTP
         end
       end
 
+      def Array.try_convert(value)
+        return value if value.instance_of?(Array)
+        return nil if !value.respond_to?(:to_ary)
+        converted = value.to_ary
+        return converted if converted.instance_of?(Array)
+
+        cname = value.class.name
+        raise TypeError, "can't convert %s to %s (%s#%s gives %s)" %
+          [cname, Array.name, cname, :to_ary, converted.class.name]
+      end unless Array.respond_to?(:try_convert)
+
       def escape_query(query) # :nodoc:
-        query.collect { |attr, value|
-          if value.respond_to?(:read)
-            value = value.read
+        pairs = []
+        query.each { |attr, value|
+          left = escape(attr.to_s) << '='
+          if values = Array.try_convert(value)
+            values.each { |value|
+              if value.respond_to?(:read)
+                value = value.read
+              end
+              pairs.push(left + escape(value.to_s))
+            }
+          else
+            if value.respond_to?(:read)
+              value = value.read
+            end
+            pairs.push(left << escape(value.to_s))
           end
-          escape(attr.to_s) << '=' << escape(value.to_s)
-        }.join('&')
+        }
+        pairs.join('&')
       end
 
       # from CGI.escape

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -882,6 +882,18 @@ EOS
     assert_equal({}, check_query_get(''))
     assert_equal({'1'=>'2'}, check_query_get({1=>StringIO.new('2')}))
     assert_equal({'1'=>'2', '3'=>'4'}, check_query_get(StringIO.new('3=4&1=2')))
+
+    hash = check_query_get({"a"=>["A","a"], "B"=>"b"})
+    assert_equal({'a'=>'A', 'B'=>'b'}, hash)
+    assert_equal(['A','a'], hash['a'].to_ary)
+
+    hash = check_query_get({"a"=>WEBrick::HTTPUtils::FormData.new("A","a"), "B"=>"b"})
+    assert_equal({'a'=>'A', 'B'=>'b'}, hash)
+    assert_equal(['A','a'], hash['a'].to_ary)
+
+    hash = check_query_get({"a"=>[StringIO.new("A"),StringIO.new("a")], "B"=>StringIO.new("b")})
+    assert_equal({'a'=>'A', 'B'=>'b'}, hash)
+    assert_equal(['A','a'], hash['a'].to_ary)
   end
 
   def test_post_body


### PR DESCRIPTION
e.g. `{ x: 'a', y: [1,2,3] }` is encoded into `"x=a&y=1&y=2&y=3"`.

Passing multiple values is very common in web API calls and this enhancement will greatly help you avoid rewriting a beautiful hash into an ugly looking dynamically composed array of pairs when it turns out some of the parameters to pass have multiple values.
