### PR TITLE
Fix encoding inconsistencies with OpenSSL::SSL::SSLSocket

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -1062,10 +1062,8 @@ private
     @debug_dev << "\n\n= Response\n\n" if @debug_dev
     do_get_header(req, res, sess)
     conn.push(res)
-    set_encoding(content, res.body_encoding)
-    content_encoding = content.respond_to?(:encoding) ? content.encoding : nil
     sess.get_body do |part|
-      set_encoding(part, content_encoding)
+      set_encoding(part, res.body_encoding)
       if block
         block.call(res, part)
       else


### PR DESCRIPTION
There is some inconsistent encoding behavior that I have tried to fix here. In particular OpenSSL::SSL::SSLSocket returns strings with different encoding types at times and can lead to an impedance mismatch of sorts. For instance if a body contains something like so:

``` html
<ul>
<li> • Test one
<li> • Test two
</ul>
```

The bullet is an encoded character and lets say the body is chunked between the "li" elements. If the first part is encoded as ASCII_8BIT and the second part is encoded as US_ASCII it will raise an exception (Encoding::CompatibilityError) in HTTPClient#do_get_block where we concatenate the content:

``` ruby
content << part
```
