### PR TITLE
Allow leading dots in no_proxy entries

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -1045,7 +1045,7 @@ private
       return false
     end
     @no_proxy.scan(/([^:,]+)(?::(\d+))?/) do |host, port|
-      if /(\A|\.)#{Regexp.quote(host)}\z/i =~ uri.host &&
+      if /(\A|\.)#{Regexp.quote(host.gsub(/^\./,''))}\z/i =~ uri.host &&
           (!port || uri.port == port.to_i)
         return true
       end


### PR DESCRIPTION
On our systems the no_proxy environment variable contains host suffixes with leading dots.
(e.g: "localhost,.corp")
This normally works with a lot of unix command line tools (git, wget, etc).
