### PR TITLE
Adding ok? convenience method to HTTP:Message

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -1027,6 +1027,11 @@ module HTTP
         }
       end
     end
+
+    # Convenience method to return boolean of whether we had a successful request
+    def ok?
+      HTTP::Status.successful?(status)
+    end
   end
 
 

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -1313,6 +1313,17 @@ EOS
     assert_equal('PART_NUMBER', res.cookies[1].name)
   end
 
+  def test_ok_response_success
+    res = HTTP::Message.new_response('response')
+    assert_true res.ok?
+    res.status = 404
+    assert_false res.ok?
+    res.status = 500
+    assert_false res.ok?
+    res.status = 302
+    assert_false res.ok?
+  end
+
   if !defined?(JRUBY_VERSION) and RUBY_VERSION < '1.9'
     def test_timeout_scheduler
       assert_equal('hello', @client.get_content(serverurl + 'hello'))


### PR DESCRIPTION
I recently converted our project from using HTTParty to httpclient.  One thing I missed having was the ok? method for the response.  Since it was fairly simple to patch it in I figured why not contribute back in case anyone else found it useful.
