### PR TITLE
support for boolean values when making POST/PUT requests with multiipart/form Content-Type

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -633,7 +633,7 @@ module HTTP
       def build_query_multipart_str(query, boundary)
         parts = Parts.new
         query.each do |attr, value|
-          value ||= ''
+          value = '' if value.nil?
           headers = ["--#{boundary}"]
           if Message.file?(value)
             remember_pos(value)

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -685,6 +685,18 @@ EOS
     assert_equal("post,--hello\r\nContent-Disposition: form-data; name=\"1\"\r\n\r\n2\r\n--hello\r\nContent-Disposition: form-data; name=\"3\"\r\n\r\n4\r\n--hello--\r\n\r\n", res.content)
   end
 
+  def test_post_with_custom_multipart_and_boolean_params
+    param = [['boolean_true', true]]
+    ext = { 'content-type' => 'multipart/form-data' }
+    assert_equal("post", @client.post(serverurl + 'servlet').content[0, 4], ext)
+    res = @client.post(serverurl + 'servlet', param, ext)
+    assert_match(/Content-Disposition: form-data; name="boolean_true"\r\n\r\ntrue\r\n/, res.content)
+    #
+    param = [['boolean_false', false]]
+    res = @client.post(serverurl + 'servlet', param, ext)
+    assert_match(/Content-Disposition: form-data; name="boolean_false"\r\n\r\nfalse\r\n/, res.content)
+  end
+
   def test_post_with_file
     STDOUT.sync = true
     File.open(__FILE__) do |file|


### PR DESCRIPTION
I'm aware that this could be done before sending body parameters through HTTPClient, but it already works for TrueClass objects (they're cast to a String object with value 'true'), so I've decided to make it work for FalseClass objects too.

ran the unit test suit with ruby 1.9.3 p194 and ruby 1.8.7 p370
