### PR TITLE
Avoiding HttpClient::Message::Body#dump causes Encoding::CompatibilityError in some cases

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 # HTTPClient - HTTP client library.
 # Copyright (C) 2000-2009  NAKAMURA, Hiroshi  <nahi@ruby-lang.org>.
 #


### PR DESCRIPTION
When message body includes both files and UTF-8 strings, dumping the request/response causes Encoding::CompatibilityError.
1 line magic comment somehow fixed this issue.
(I'm still not good at ruby 1.9 encode handling..)
