### PR TITLE
A new cookie never be accepted if an HTTPClient has the same expired cookie.

### DIFF
--- a/lib/httpclient/cookie.rb
+++ b/lib/httpclient/cookie.rb
@@ -303,6 +303,7 @@ class WebAgent
 
       cookie = nil
       @cookies.synchronize do
+        check_expired_cookies
         cookie = @cookies.find { |c|
           c.domain == domain && c.path == path && c.name == given.name
         }
@@ -311,7 +312,6 @@ class WebAgent
           cookie.use = true
           @cookies << cookie
         end
-        check_expired_cookies
       end
 
       cookie.domain = domain

--- a/test/test_cookie.rb
+++ b/test/test_cookie.rb
@@ -235,6 +235,27 @@ class TestCookieManager < Test::Unit::TestCase
     assert_equal("/", cookie.path)
   end
 
+  def test_parse_after_expiration
+    str = "inkid=n92b0ADOgACIgUb9lsjHqAAAHu2a; expires=Wed, 01-Dec-2010 00:00:00 GMT; path=/"
+    @cm.parse(str, urify('http://www.test.jp'))
+    cookie = @cm.cookies[0]
+    assert_instance_of(WebAgent::Cookie, cookie)
+    assert_equal("inkid", cookie.name)
+    assert_equal("n92b0ADOgACIgUb9lsjHqAAAHu2a", cookie.value)
+    assert_equal(Time.gm(2010, 12, 1, 0,0,0), cookie.expires)
+    assert_equal("/", cookie.path)
+
+    time = Time.now.utc.round + 60
+    expires = time.strftime("%a, %d-%b-%Y %H:%M:%S GMT")
+    str = "inkid=n92b0ADOgACIgUb9lsjHqAAAHu2a; expires=#{expires}; path=/"
+    @cm.parse(str, urify('http://www.test.jp'))
+    cookie = @cm.cookies[0]
+    assert_equal("inkid", cookie.name)
+    assert_equal("n92b0ADOgACIgUb9lsjHqAAAHu2a", cookie.value)
+    assert_equal(time, cookie.expires)
+    assert_equal("/", cookie.path)
+  end
+
   def test_find_cookie()
     str = "xmen=off,0,0,1; path=/; domain=.excite2.co.jp; expires=Wednesday, 31-Dec-2037 12:00:00 GMT"
     @cm.parse(str, urify("http://www.excite2.co.jp/"))


### PR DESCRIPTION
It seems that a new cookie never be accepted if an HTTPClient has the same expired cookie.

For example, if a cookie is configured to be expired within 5 seconds, the following
code prints received cookies in the first loop, but prints empty arrays in the second loop.

hc = HTTPClient.new
2.times do
  hc.get("http://localhost/books")
  p hc.cookies
  hc.post("http://localhost/books",
          '{"title":"hello","body":"world"}',
          "Content-Type"=>"application/json; charset=utf-8")
  p hc.cookies
  sleep 5
end

It's OK that the old cookie is expired, but the new cookie should be accepted, shouldn't it?
