### PR TITLE
Force binary encoding for recent rubies.

### DIFF
--- a/lib/httpclient/session.rb
+++ b/lib/httpclient/session.rb
@@ -20,6 +20,7 @@ require 'zlib'
 require 'httpclient/timeout'
 require 'httpclient/ssl_config'
 require 'httpclient/http'
+require 'httpclient/util'
 
 
 class HTTPClient
@@ -947,10 +948,7 @@ class HTTPClient
     def read_body_length(&block)
       return nil if @content_length == 0
       while true
-        buf = ''
-        if RUBY_VERSION >= '1.9'
-          buf.force_encoding(::Encoding::ASCII_8BIT)
-        end
+        buf = HTTPClient::Util.get_buf
         maxbytes = @read_block_size
         maxbytes = @content_length if maxbytes > @content_length
         timeout(@receive_timeout, ReceiveTimeoutError) do
@@ -973,10 +971,7 @@ class HTTPClient
 
     RS = "\r\n"
     def read_body_chunked(&block)
-      buf = ''
-      if RUBY_VERSION >= '1.9'
-        buf.force_encoding(::Encoding::ASCII_8BIT)
-      end
+      buf = HTTPClient::Util.get_buf
       while true
         len = @socket.gets(RS)
         if len.nil? # EOF
@@ -1004,10 +999,7 @@ class HTTPClient
         @readbuf = nil
       end
       while true
-        buf = ''
-        if RUBY_VERSION >= '1.9'
-          buf.force_encoding(::Encoding::ASCII_8BIT)
-        end
+        buf = HTTPClient::Util.get_buf
         timeout(@receive_timeout, ReceiveTimeoutError) do
           begin
             @socket.readpartial(@read_block_size, buf)

--- a/lib/httpclient/util.rb
+++ b/lib/httpclient/util.rb
@@ -164,6 +164,14 @@ class HTTPClient
     end
     module_function :hash_find_value
 
+    # Gets a string to be used as a binary buffer
+    def get_buf
+      buf = ''
+      defined?(Encoding::ASCII_8BIT) && buf.force_encoding(Encoding::ASCII_8BIT)
+      buf
+    end
+    module_function :get_buf
+
     # Checks if the given URI is https.
     def https?(uri)
       uri.scheme && uri.scheme.downcase == 'https'


### PR DESCRIPTION
Issue - with ruby 2.0.0, the following test case produces an invalid downloaded file from an object store server used by the Cloud Foundry project.

Expected SHA1 checksum is `b3ab606864606c9f980045653554bf4a12cadde2`, but when downloaded with httpclient 2.3.3 and ruby 2.0.0, the checksum is `477ed8c72b65e311b49953381ff22b88f986fa07`.

The file is `pcre-8.12.tar.gz`, which can be downloaded here:

http://sourceforge.net/projects/pcre/files/pcre/8.12/

This pull request will force binary encoding on several of the buffers used in httpclient. I didn't investigate outside of `session.rb` to see if other buffers need to be changed as well. Thanks!

```
require 'httpclient'

File.open("pcre-#{RUBY_VERSION}-httpclient.blob", 'wb') do |f|
  c = HTTPClient.new
  c.get('http://blob.cfblob.com/rest/objects/4e4e78bca51e121204e4e86ee8e2c904fbd4f203c8e7?uid=92b8944a45f24e94b4ad254d98ab1f25/bosh-release-uid&expires=1893484800&signature=Dn1hkvGg3Tq62uu5fcKs3tRWSUg=') do |s|
    f.write(s)
  end
end
```
