### PR TITLE
Handle UTF characters in chunked bodies.

### DIFF
--- a/lib/httpclient/session.rb
+++ b/lib/httpclient/session.rb
@@ -984,10 +984,11 @@ class HTTPClient
           return
         end
         timeout(@receive_timeout, ReceiveTimeoutError) do
-          @socket.read(@chunk_length + 2, buf)
+          @socket.read(@chunk_length, buf)
+          @socket.read(2)
         end
         unless buf.empty?
-          yield buf.slice(0, @chunk_length)
+          yield buf
         end
       end
     end


### PR DESCRIPTION
When reading a chunked body, the session was assuming the response to have one character per byte read from the socket. With ruby 2.0, this is no longer the case, and UTF characters consisting of more than 1 byte would cause the session to yield an incorrect buffer. For instance a part including a UTF rune consisting of two bytes would cause the yielded buffer to include the carriage return from the chunked transfer format.
