### PR TITLE
Make session.rb ignore negative content length

### DIFF
--- a/lib/httpclient/session.rb
+++ b/lib/httpclient/session.rb
@@ -949,7 +949,7 @@ class HTTPClient
       while true
         buf = empty_bin_str
         maxbytes = @read_block_size
-        maxbytes = @content_length if maxbytes > @content_length
+        maxbytes = @content_length if maxbytes > @content_length && @content_length > 0
         timeout(@receive_timeout, ReceiveTimeoutError) do
           begin
             @socket.readpartial(maxbytes, buf)


### PR DESCRIPTION
Some servers return negative content lengths, causing issues with httpclient.  I've set it to just use maxbytes if the content length reported is negative, which appears to work well for me.
