### PR TITLE
Strip square brackets when creating IPv6 sockets

### DIFF
--- a/lib/httpclient/session.rb
+++ b/lib/httpclient/session.rb
@@ -797,12 +797,14 @@ class HTTPClient
       socket = nil
       begin
         @debug_dev << "! CONNECT TO #{site.host}:#{site.port}\n" if @debug_dev
+				clean_host = site.host.delete("[]")
+				clean_local = @socket_local.host.delete("[]")
         if str = @test_loopback_http_response.shift
-          socket = LoopBackSocket.new(site.host, site.port, str)
+          socket = LoopBackSocket.new(clean_host, site.port, str)
         elsif @socket_local == Site::EMPTY
-          socket = TCPSocket.new(site.host, site.port)
+          socket = TCPSocket.new(clean_host, site.port)
         else
-          socket = TCPSocket.new(site.host, site.port, @socket_local.host, @socket_local.port)
+          socket = TCPSocket.new(clean_host, site.port, clean_local, @socket_local.port)
         end
         if @debug_dev
           @debug_dev << "! CONNECTION ESTABLISHED\n"


### PR DESCRIPTION
The current code base tries to pass the site.host field unmodified when creating a new socket.  For IPv6 hosts, the IP address is wrapped in square brackets which the TCPSocket object does not understand.  I've made it so that such references to hosts in the create_socket() method use sanitized versions of the host information instead of the raw info.
