### PR TITLE
conditionally use either meta_add_field or meta_add_field2

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -233,7 +233,11 @@ module HTTP
         def set_body_encoding
           if type = self.content_type
             OpenURI::Meta.init(o = '')
-            o.meta_add_field('content-type', type)
+            if o.respond_to?(:meta_add_field)
+              o.meta_add_field('content-type', type)
+            else
+              o.meta_add_field2('content-type', [type])
+            end
             @body_encoding = o.encoding
           end
         end


### PR DESCRIPTION
In ruby 2.1.0, they seem to have replaced meta_add_field with
meta_add_field2, which takes an array as the second argument rather than
just a value. This just conditionally calls the right one with
respond_to?
