### PR TITLE
Change default SSL version to nil to use TLS version negotiation.

### DIFF
--- a/lib/httpclient/ssl_config.rb
+++ b/lib/httpclient/ssl_config.rb
@@ -34,7 +34,9 @@ class HTTPClient
   class SSLConfig
     include OpenSSL if SSLEnabled
 
-    # String name of OpenSSL's SSL version method name: SSLv2, SSLv23 or SSLv3
+    # String name of OpenSSL's SSL version method name: TLSv1_2, TLSv1_1, TLSv1,
+    # SSLv2, SSLv23, SSLv3 or nil to allow version negotiation (default).
+    # See {OpenSSL::SSL::SSLContext::METHODS}.
     attr_reader :ssl_version
     # OpenSSL::X509::Certificate:: certificate for SSL client authenticateion.
     # nil by default. (no client authenticateion)
@@ -83,7 +85,7 @@ class HTTPClient
       @verify_callback = nil
       @dest = nil
       @timeout = nil
-      @ssl_version = "SSLv3"
+      @ssl_version = nil
       @options = defined?(SSL::OP_ALL) ? SSL::OP_ALL | SSL::OP_NO_SSLv2 : nil
       # OpenSSL 0.9.8 default: "ALL:!ADH:!LOW:!EXP:!MD5:+SSLv2:@STRENGTH"
       @ciphers = "ALL:!aNULL:!eNULL:!SSLv2" # OpenSSL >1.0.0 default
@@ -283,7 +285,7 @@ class HTTPClient
       ctx.timeout = @timeout
       ctx.options = @options
       ctx.ciphers = @ciphers
-      ctx.ssl_version = @ssl_version
+      ctx.ssl_version = @ssl_version if @ssl_version
     end
 
     # post connection check proc for ruby < 1.8.5.


### PR DESCRIPTION
By default httpclient sets SSLContext version to SSLv3 and therefore disables TLS  version negotiation. That means every library using httpclient that does not unset SSL version always uses only SSLv3 and cannot connect to a server that only supports TLSv1.0+.

This also leads to the problem that if httpclient was not used directly but by a third-party library it will suffer the same problem without any way to change this outside patching the library's usage of httpclient.

Error when connecting to a TLS-only server using default settings:

```
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server hello A: sslv3 alert handshake failure
```

If no SSL version is given to SSLContext it will correctly negotiate the version with the server and (in my case) will use TLSv1.2. Additional allowing the client to negotiate the version with the server would allow the client to use the best possible available protocol version. SSLv2 would still be not allowed as it is disabled in the cipher suite list (`!SSLv2`).

This PR changes the default value to `nil`. If SSL version is set to `nil` it will not be passed to the SSLContext. I've also updated the corresponding documentation.
