### PR TITLE
Use system wide CA cert store by default.

### DIFF
--- a/lib/httpclient/ssl_config.rb
+++ b/lib/httpclient/ssl_config.rb
@@ -269,8 +269,7 @@ class HTTPClient
 
     # interfaces for SSLSocketWrap.
     def set_context(ctx) # :nodoc:
-      load_trust_ca unless @cacerts_loaded
-      @cacerts_loaded = true
+      set_default_paths unless @cacerts_loaded
       # Verification: Use Store#verify_callback instead of SSLContext#verify*?
       ctx.cert_store = @cert_store
       ctx.verify_mode = @verify_mode


### PR DESCRIPTION
Not using the system wide CA cert store as the default cert store makes it impossible to use a different list of CA certs when not using httpclient directly but through a third-party library.

It also leads to unexpected errors as most software will work except httpclient when e.g. you have imported your own internal CA certificates into the system wide CA certificate chain. Additional you profit from security updates for CA certificates provided by the operation system vendor/community.

This PR changes the SSLContext setup to use the default system wide CA certs instead of the bundled ones if nothing else was configured.

A workaround is calling `http_client.ssl_config.set_default_paths` but that again is not possible if you're not using httpclient directly but by a third-party application or library.
