### PR TITLE
Add Ruby 2.1.0 to the list of supported Rubies.  Get rbx specs running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - ruby-head
   - jruby-19mode
   - jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,11 @@ platform :jruby do
   gem 'jruby-openssl'
 end
 
+platform :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'rubinius-developer_tools'
+end
+
 group :development do
   gem 'rake', :require => false
   gem 'rdoc'


### PR DESCRIPTION
1. Added Ruby 2.1.0 to the list of supported Rubies.
2. Added now required gems for Rubinius to get the build running again

With this PR Travis is all green, rbx included.
