### PR TITLE
Allow TLSv1 protocol by default

### DIFF
--- a/lib/httpclient/ssl_config.rb
+++ b/lib/httpclient/ssl_config.rb
@@ -83,7 +83,7 @@ class HTTPClient
       @verify_callback = nil
       @dest = nil
       @timeout = nil
-      @ssl_version = "SSLv3"
+      @ssl_version = "SSLv23"
       @options = defined?(SSL::OP_ALL) ? SSL::OP_ALL | SSL::OP_NO_SSLv2 : nil
       # OpenSSL 0.9.8 default: "ALL:!ADH:!LOW:!EXP:!MD5:+SSLv2:@STRENGTH"
       @ciphers = "ALL:!aNULL:!eNULL:!SSLv2" # OpenSSL >1.0.0 default


### PR DESCRIPTION
The current settings means httpclient will only do SSLv3 protocol. Using
the SSLv23 actually means trying to find the a working one including
TLSv1. For more details see:

http://www.openssl.org/docs/ssl/SSL_CTX_new.html

Here's also information on the same topic:

http://stackoverflow.com/questions/11059059/is-it-possible-to-enable-tls-v1-2-in-ruby-if-so-how
