### PR TITLE
Allow blocks for request function to retrieve the response object

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -764,9 +764,13 @@ class HTTPClient
     end
     uri = urify(uri)
     if block
-      filtered_block = proc { |res, str|
-        block.call(str)
-      }
+      if block.arity == 1
+        filtered_block = proc { |res, str|
+          block.call(str)
+        }
+      else
+        filtered_block = block
+      end
     end
     if follow_redirect
       follow_redirect(method, uri, query, body, header, &block)


### PR DESCRIPTION
The problem I ran into came about when working with multipart/mixed requests where a boundary string is set within the content-type header. See http://www.w3.org/Protocols/rfc1341/7_2_Multipart.html if interested in definition.

The server needs to tell the client what the boundary string is via the content-type header, however when running the request method with a provided block, it forces that block to have only 1 parameter, the current chunk of data being dealt with. This means I don't have boundary string needed to help programmatically separate my data into the original source data.

Initially I had tried setting a value like this:

``` ruby
resp = http.request('url') do |chunk|
...
end
```

Which oddly enough worked to a point, but eventually failed after the 50th request with a LocalJumpError, which should have been the result all along.

Anyways, the proposed change here is to keep the filtering strategy in place when the arity of the block passed in is 1, so that users will only get back that chunk. However, if as in my case, they explicitly use a block with an arity of 2, they can get back the response object and the chunk.

Note:
I tried to add a test for this scenario, but ran into significant issues with the current testing framework.
- 1 test failed consistently (before/after my changes)
- 1 test failed ~50% of the time (before/after my changes)
- My new test worked on windows but failed on Linux, despite the functionality itself working on either OS.
