### PR TITLE
Let OpenSSL decide which TLS protocol version is used by default.

### DIFF
--- a/lib/httpclient/ssl_config.rb
+++ b/lib/httpclient/ssl_config.rb
@@ -34,7 +34,12 @@ class HTTPClient
   class SSLConfig
     include OpenSSL if SSLEnabled
 
-    # String name of OpenSSL's SSL version method name: SSLv2, SSLv23 or SSLv3
+    # Which TLS protocol version (also called method) will be used. Defaults
+    # to :auto which means that OpenSSL decides (In my tests this resulted 
+    # with always the highest available protocol being used).
+    # 
+    # See the content of OpenSSL::SSL::SSLContext::METHODS for a list of
+    # available versions in your specific Ruby environment.
     attr_reader :ssl_version
     # OpenSSL::X509::Certificate:: certificate for SSL client authenticateion.
     # nil by default. (no client authenticateion)
@@ -83,7 +88,7 @@ class HTTPClient
       @verify_callback = nil
       @dest = nil
       @timeout = nil
-      @ssl_version = "SSLv3"
+      @ssl_version = :auto
       @options = defined?(SSL::OP_ALL) ? SSL::OP_ALL | SSL::OP_NO_SSLv2 : nil
       # OpenSSL 0.9.8 default: "ALL:!ADH:!LOW:!EXP:!MD5:+SSLv2:@STRENGTH"
       @ciphers = "ALL:!aNULL:!eNULL:!SSLv2" # OpenSSL >1.0.0 default
@@ -283,7 +288,7 @@ class HTTPClient
       ctx.timeout = @timeout
       ctx.options = @options
       ctx.ciphers = @ciphers
-      ctx.ssl_version = @ssl_version
+      ctx.ssl_version = @ssl_version unless @ssl_version == :auto
     end
 
     # post connection check proc for ruby < 1.8.5.


### PR DESCRIPTION
I use Gem in a Box, a Ruby project that allows to create personal self-hosted gem repsitories. Gem in a Box uses httpclient to connect to the gem repository. After reviewing my server's TLS setup in the aftermath of the OpenSSL heartbleed bug, I decided only to allow protocol versions of TLSv1 and higher on my server. A decision quite a few fellow administrators made because of security vulnerabilites in SSLv3 and below.

Now after I did this change, Gem in a Box refused to work with the following message:

```
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server hello A: sslv3 alert handshake failure
```

I traced this problem back until I found the source in httpclient. Even though OpenSSL can find the best protocol version to use by itself, you set it only to use SSLv3 by default. I think this is a very bad idea and hereby provide a patch which lets OpenSSL do its own decision again by default.

Please double check my changes because I am not so familiar with OpenSSL itself and the documentation of the Ruby binding is severely lacking. I tested my changes and hope this patch is acceptable.
