### PR TITLE
Bundle ci_reporter_test_unit that was extracted from ci_reporter recently

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ group :development do
   gem 'simplecov', :platforms => [:ruby_19, :ruby_20]
   # For Jenkins
   gem 'test-unit'
-  gem 'ci_reporter'
-  gem 'ci_reporter_test_unit'
+  # ci_reporter 2.x doesn't support Ruby 1.8
+  gem 'ci_reporter', '~> 1.9'
   gem 'simplecov-rcov', :platforms => [:ruby_19, :ruby_20]
   gem 'pry'
   gem 'rack'


### PR DESCRIPTION
Turned out that the CI fail on #208 was because ci_reporter gem has been separeted into serveral gems since its version 2. https://github.com/ci-reporter/ci_reporter/commit/5b01f524c521914d577998e57cf5252ebac2666d
