### PR TITLE
do not require and fail 3 times every time

### DIFF
--- a/lib/httpclient/auth.rb
+++ b/lib/httpclient/auth.rb
@@ -12,28 +12,9 @@ require 'mutex_m'
 
 
 class HTTPClient
-
-  begin
-    require 'net/ntlm'
-    NTLMEnabled = true
-  rescue LoadError
-    NTLMEnabled = false
-  end
-
-  begin
-    require 'win32/sspi'
-    SSPIEnabled = true
-  rescue LoadError
-    SSPIEnabled = false
-  end
-
-  begin
-    require 'gssapi'
-    GSSAPIEnabled = true
-  rescue LoadError
-    GSSAPIEnabled = false
-  end
-
+  NTLMEnabled = defined?(NTLM)
+  SSPIEnabled = defined?(Win32::SSPI)
+  GSSAPIEnabled = defined?(GSSAPI)
 
   # Common abstract class for authentication filter.
   #


### PR DESCRIPTION
all these libraries just serve some exotic edge-case, why should the 99% pay for them ?

(also requiring things that you might not want loaded is kind of bad ... for example gssapi prints some annoying warnings on osx)

@nahi 
