### PR TITLE
Topic base url

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -324,6 +324,8 @@ class HTTPClient
   # How many times get_content and post_content follows HTTP redirect.
   # 10 by default.
   attr_accessor :follow_redirect_count
+  # Base url of resources.
+  attr_accessor :base_url
 
   # Set HTTP version as a String:: 'HTTP/1.0' or 'HTTP/1.1'
   attr_proxy(:protocol_version, true)
@@ -366,7 +368,7 @@ class HTTPClient
   #  * :proxy - proxy url string
   #  * :agent_name - User-Agent String
   #  * :from - from header String
-  #  * :base_url - base URL for all resource URL
+  #  * :base_url - base URL of resources
   #  * :force_basic_auth - flag for sending Authorization header w/o gettin 401 first
   # User-Agent and From are embedded in HTTP request Header if given.
   # From header is not set without setting it explicitly.
@@ -376,10 +378,12 @@ class HTTPClient
   #   from = 'from@example.com'
   #   HTTPClient.new(proxy, agent_name, from)
   #
-  # You can use a keyword argument style Hash.  Keys are :proxy, :agent_name
-  # and :from.
+  # After you set base_url, all resources you pass to get, post and other
+  # methods are recognized to be prefixed with base_url. Say base_url is
+  # 'https://api.example.com/v1, get('/users') is the same as
+  # get('https://api.example.com/v1/users') internally. You can also pass
+  # full URL from 'http://' even after setting base_url.
   #
-  #   HTTPClient.new(:agent_name => 'MyAgent/0.1')
   def initialize(*args)
     proxy, agent_name, from, base_url, force_basic_auth =
       keyword_argument(args, :proxy, :agent_name, :from, :base_url, :force_basic_auth)

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -670,7 +670,8 @@ EOS
     assert_equal(param, params(res.header["x-query"][0]))
     assert_nil(res.contenttype)
     #
-    url = '/servlet?5=6&7=8'
+    @client.base_url = serverurl[0..-1] + '/servlet'
+    url = '?5=6&7=8'
     res = @client.get(url, param)
     assert_equal(param.merge("5"=>"6", "7"=>"8"), params(res.header["x-query"][0]))
     assert_nil(res.contenttype)


### PR DESCRIPTION
Add :base_url to HTTPClient configuration
  api = HTTPClient.new(:base_url => 'https://api.example.com/v1')
  api.get("/users.json") # => Get https://api.example.com/v1/users.json
  api.get("https://localhost/path") # => https://localhost/path

Passing path to get, post, etc. is recognized as a request to :base_url + uri.  If you pass full URL :base_url is ignored.
