### PR TITLE
added lib in require path

### DIFF
--- a/httpclient.gemspec
+++ b/httpclient.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new { |s|
   s.executables = ['httpclient']
   s.homepage = 'https://github.com/nahi/httpclient'
   s.summary = 'gives something like the functionality of libwww-perl (LWP) in Ruby'
+  s.require_paths = ['lib']
   s.files = Dir.glob('{bin,lib,sample,test}/**/*') + ['README.md']
   s.license = 'ruby'
 }


### PR DESCRIPTION
`lib` is not included in [require_paths](http://guides.rubygems.org/specification-reference/#require_paths=) for this gem, by default. This makes me include the `lib` in `$LOAD_PATH` repeatedly for scripts. 
