### PR TITLE
Cut down constant cache invalidations

### DIFF
--- a/lib/httpclient/cookie.rb
+++ b/lib/httpclient/cookie.rb
@@ -210,6 +210,13 @@ class WebAgent
     end
   end
 
+  ##
+  # An Array class that already includes the MonitorMixin module.
+  #
+  class SynchronizedArray < Array
+    include MonitorMixin
+  end
+
   class CookieManager
     include CookieUtils
 
@@ -223,8 +230,7 @@ class WebAgent
     attr_accessor :accept_domains, :reject_domains
 
     def initialize(file=nil)
-      @cookies = Array.new
-      @cookies.extend(MonitorMixin)
+      @cookies = SynchronizedArray.new
       @cookies_file = file
       @is_saved = true
       @reject_domains = Array.new
@@ -233,8 +239,11 @@ class WebAgent
     end
 
     def cookies=(cookies)
-      @cookies = cookies
-      @cookies.extend(MonitorMixin)
+      if cookies.is_a?(SynchronizedArray)
+        @cookies = cookies
+      else
+        @cookies = SynchronizedArray.new(cookies)
+      end
     end
 
     def save_all_cookies(force = nil, save_unused = true, save_discarded = true)


### PR DESCRIPTION
See bf5f9063db36b0f74972d1afe5b7cf012cd20308 for all the juicy details. I've been running this patch in a production app for a day or so now, which produces the following graph:

![screenshot - 051114 - 15 02 05](https://cloud.githubusercontent.com/assets/86065/4918767/5971c95e-64f4-11e4-9484-27aa497bea56.png)

This graph shows the total amount of constant invalidations over time. The gaps are caused due to the app only running for a few hours, twice a day. If you look closely the last bump is a bit smaller, due to the changes in this pull request. Note that the graph line only shows the average amount of invalidations per transaction (= job the app processes). At peak level the total amount of invalidations went down from 153k to 102k invalidations.

I'm currently trying to see what's causing the remainder of invalidations. I'll give a heads up if this PR is considered done from my end.
