### PR TITLE
Fix warning-mode nitpicks

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -420,7 +420,7 @@ class HTTPClient
     load_environment
     self.proxy = proxy if proxy
     keep_webmock_compat
-    instance_eval &block if block
+    instance_eval(&block) if block
   end
 
   # webmock 1.6.2 depends on HTTP::Message#body.content to work.
@@ -1081,7 +1081,7 @@ private
   def protect_keep_alive_disconnected
     begin
       yield
-    rescue KeepAliveDisconnected => e
+    rescue KeepAliveDisconnected
       # Force to create new connection
       Thread.current[:HTTPClient_AcquireNewConnection] = true
       begin

--- a/lib/httpclient/auth.rb
+++ b/lib/httpclient/auth.rb
@@ -535,7 +535,7 @@ class HTTPClient
     def get(req)
       target_uri = req.header.request_uri
       synchronize {
-        domain_uri, param = @challenge.find { |uri, v|
+        _domain_uri, param = @challenge.find { |uri, v|
           Util.uri_part_of(target_uri, uri)
         }
         return nil unless param

--- a/test/test_auth.rb
+++ b/test/test_auth.rb
@@ -124,6 +124,7 @@ class TestAuth < Test::Unit::TestCase
       end
       # Make it work if @value == nil
       class SecurityBuffer < FieldSet
+        remove_method(:data_size) if method_defined?(:data_size)
         def data_size
           @active && @value ? @value.size : 0
         end
@@ -230,7 +231,7 @@ class TestAuth < Test::Unit::TestCase
       c.www_auth.basic_auth.instance_eval { @scheme = "BASIC" }
       c.set_auth("http://localhost:#{serverport}/", 'admin', 'admin')
 
-      threads = 100.times.map { |idx|
+      100.times.map { |idx|
         Thread.new(idx) { |idx2|
           Thread.abort_on_exception = true
           Thread.pass
@@ -251,7 +252,7 @@ class TestAuth < Test::Unit::TestCase
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
     c.debug_dev = str = ''
     c.get_content("http://localhost:#{serverport}/basic_auth/sub/dir/")
-    assert_match /Authorization: Basic YWRtaW46YWRtaW4=/, str
+    assert_match(/Authorization: Basic YWRtaW46YWRtaW4=/, str)
   end
 
   def test_digest_auth
@@ -267,7 +268,7 @@ class TestAuth < Test::Unit::TestCase
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
     c.debug_dev = str = ''
     c.get_content("http://localhost:#{serverport}/digest_auth/sub/dir/")
-    assert_match /Authorization: Digest/, str
+    assert_match(/Authorization: Digest/, str)
   end
 
   def test_digest_auth_with_block

--- a/test/test_cookie.rb
+++ b/test/test_cookie.rb
@@ -290,8 +290,8 @@ EOF
   def test_load_cookies_escaped
     uri = urify('http://example.org/')
     f = Tempfile.new('test_cookie')
-    File.open(f.path, 'w') do |f|
-      f.write <<EOF
+    File.open(f.path, 'w') do |out|
+      out.write <<EOF
 http://example.org/	key1	"value"	0	.example.org	/	13	0			
 http://example.org/	key2	""	0	.example.org	/	13	0			
 http://example.org/	key3		0	.example.org	/	13	0			

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -770,8 +770,8 @@ EOS
 
   def test_get_with_block_arity_2
     called = false
-    res = @client.get(serverurl + 'servlet') { |res, str|
-      assert_equal(200, res.status)
+    res = @client.get(serverurl + 'servlet') { |blk_res, str|
+      assert_equal(200, blk_res.status)
       assert_equal('get', str)
       called = true
     }
@@ -783,7 +783,7 @@ EOS
   def test_get_with_block_string_recycle
     @client.read_block_size = 2
     body = []
-    res = @client.get(serverurl + 'servlet') { |str|
+    _res = @client.get(serverurl + 'servlet') { |str|
       body << str
     }
     assert_equal(2, body.size)
@@ -800,7 +800,7 @@ EOS
     url = "http://localhost:#{server.addr[1]}/"
     body = []
     begin
-      res = @client.get(url + 'chunked') { |str|
+      _res = @client.get(url + 'chunked') { |str|
         body << str
       }
     ensure
@@ -955,7 +955,7 @@ EOS
       1
     end
     @client.debug_dev = str = StringIO.new
-    res = @client.post(serverurl + 'servlet', { :file => myio })
+    _res = @client.post(serverurl + 'servlet', { :file => myio })
     assert_match(/\r\n4\r\n/, str.string, 'should send "4" not "45"')
   end
 
@@ -972,7 +972,7 @@ EOS
       end
     end
     @client.debug_dev = str = StringIO.new
-    res = @client.post(serverurl + 'servlet', { :file1 => myio1, :file2 => myio2 })
+    _res = @client.post(serverurl + 'servlet', { :file1 => myio1, :file2 => myio2 })
     assert_match(/\r\n45\r\n/, str.string)
   end
 
@@ -1243,7 +1243,7 @@ EOS
 
   def test_http_custom_date_header
     @client.debug_dev = (str = "")
-    res = @client.get(serverurl + 'hello', :header => {'Date' => 'foo'})
+    _res = @client.get(serverurl + 'hello', :header => {'Date' => 'foo'})
     lines = str.split(/(?:\r?\n)+/)
     assert_equal('Date: foo', lines[4])
   end

--- a/test/test_webagent-cookie.rb
+++ b/test/test_webagent-cookie.rb
@@ -440,8 +440,8 @@ EOF
   def test_load_cookies_escaped
     uri = urify('http://example.org/')
     f = Tempfile.new('test_cookie')
-    File.open(f.path, 'w') do |f|
-      f.write <<EOF
+    File.open(f.path, 'w') do |out|
+      out.write <<EOF
 http://example.org/	key	"value"	0	.example.org	/	13	0			
 http://example.org/	key	""		.example.org	/	13	0			
 http://example.org/	key			.example.org	/	13	0			


### PR DESCRIPTION
Eliminate -w warnings.  Most of these are just in the tests, but a few are encountered when using httpclient.

To see the warnings:

    ruby -w bundle exec test/runner.rb

The warnings were:

```
/home/wayne/lab/httpclient/test/test_auth.rb:233: warning: assigned but unused variable - threads
/home/wayne/lab/httpclient/test/test_auth.rb:254: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/home/wayne/lab/httpclient/test/test_auth.rb:270: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/home/wayne/.rvm/gems/ruby-2.2.1/gems/httpclient-2.6.0.1/lib/httpclient.rb:1083: warning: assigned but unused variable - e
/home/wayne/.rvm/gems/ruby-2.2.1/gems/httpclient-2.6.0.1/lib/httpclient/auth.rb:538: warning: assigned but unused variable - domain_uri
/home/wayne/lab/httpclient/test/test_auth.rb:127: warning: method redefined; discarding old data_size
/home/wayne/.rvm/gems/ruby-2.2.1/gems/rubyntlm-0.5.0/lib/net/ntlm/security_buffer.rb:42: warning: previous definition of data_size was here
/home/wayne/lab/httpclient/test/test_webagent-cookie.rb:443: warning: shadowing outer local variable - f
/home/wayne/lab/httpclient/test/test_cookie.rb:293: warning: shadowing outer local variable - f
/home/wayne/lab/httpclient/test/test_httpclient.rb:773: warning: shadowing outer local variable - res
/home/wayne/lab/httpclient/test/test_httpclient.rb:786: warning: assigned but unused variable - res
/home/wayne/lab/httpclient/test/test_httpclient.rb:803: warning: assigned but unused variable - res
/home/wayne/lab/httpclient/test/test_httpclient.rb:958: warning: assigned but unused variable - res
/home/wayne/lab/httpclient/test/test_httpclient.rb:975: warning: assigned but unused variable - res
/home/wayne/lab/httpclient/test/test_httpclient.rb:1246: warning: assigned but unused variable - res
```
