### PR TITLE
Join base url with relative path

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -1268,7 +1268,7 @@ private
   def to_resource_url(uri)
     u = urify(uri)
     if @base_url && u.scheme.nil? && u.host.nil?
-      urify(@base_url + uri)
+      URI.join(@base_url, uri)
     else
       u
     end


### PR DESCRIPTION
Currently, if `@base_url` doesn't have the trailing slash and relative path doesn't start with one, we'll have a broken domain.