### PR TITLE
reduce deprecated warning

### DIFF
--- a/lib/httpclient/timeout.rb
+++ b/lib/httpclient/timeout.rb
@@ -133,6 +133,10 @@ end
           scheduler.cancel(period) if scheduler and period
         end
       end
+    else
+      def timeout(sec, ex = nil, &block)
+        ::Timeout.timeout(sec, ex, &block)
+      end
     end
   end
 


### PR DESCRIPTION
Object#timeout is deprecated in Ruby 2.3.

```
irb(main):001:0> RUBY_VERSION
=> "2.3.0"
irb(main):002:0> require 'httpclient'
=> true
irb(main):003:0> HTTPClient.get('http://google.com')
/Users/takkanm/.rbenv/versions/2.3.0-preview1/lib/ruby/gems/2.3.0/gems/httpclient-2.7.0.1/lib/httpclient/session.rb:734:in `connect': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/takkanm/.rbenv/versions/2.3.0-preview1/lib/ruby/gems/2.3.0/gems/httpclient-2.7.0.1/lib/httpclient/session.rb:500:in `query': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/takkanm/.rbenv/versions/2.3.0-preview1/lib/ruby/gems/2.3.0/gems/httpclient-2.7.0.1/lib/httpclient/session.rb:787:in `parse_header': Object#timeout is deprecated, use Timeout.timeout instead.
/Users/takkanm/.rbenv/versions/2.3.0-preview1/lib/ruby/gems/2.3.0/gems/httpclient-2.7.0.1/lib/httpclient/session.rb:867:in `read_body_length': Object#timeout is deprecated, use Timeout.timeout instead.
=> #<HTTP::Message:0x007ff7a2afb968 @http_header=#<HTTP::Message::Headers:0x007ff7a2afb940 @http_version="1.1", @body_size=0, @chunked=false, @request_method="GET", @request_uri=#<URI::HTTP http://google.com>, @request_query=nil, @request_absolute_uri=nil, @status_code=302, @reason_phrase="Found", @body_type=nil, @body_charset=nil, @body_date=nil, @body_encoding=#<Encoding:UTF-8>, @is_request=false, @header_item=[["Cache-Control", "private"], ["Content-Type", "text/html; charset=UTF-8"], ["Location", "http://www.google.co.jp/?gfe_rd=cr&ei=fxNLVt6QJIyg8wedgoHABg"], ["Content-Length", "261"], ["Date", "Tue, 17 Nov 2015 11:46:07 GMT"], ["Server", "GFE/2.0"]], @dumped=false>, @peer_cert=nil, @http_body=#<HTTP::Message::Body:0x007ff7a2afb8c8 @body="<HTML><HEAD><meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\">\n<TITLE>302 Moved</TITLE></HEAD><BODY>\n<H1>302 Moved</H1>\nThe document has moved\n<A HREF=\"http://www.google.co.jp/?gfe_rd=cr&amp;ei=fxNLVt6QJIyg8wedgoHABg\">here</A>.\r\n</BODY></HTML>\r\n", @size=0, @positions=nil, @chunk_size=nil>, @previous=nil>
```