### PR TITLE
Remove warning when loading cookie library

### DIFF
--- a/lib/httpclient/webagent-cookie.rb
+++ b/lib/httpclient/webagent-cookie.rb
@@ -456,4 +456,4 @@ end
 
 class HTTPClient
   CookieManager = WebAgent::CookieManager
-end
+end unless defined?(HTTPClient::CookieManager)


### PR DESCRIPTION
If both cookie and webagent-cookie are loaded, a warning shows up:

```
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient/webagent-cookie.rb:458:
warning: already initialized constant HTTPClient::CookieManager
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/httpclient-2.6.0.1/lib/httpclient/cookie.rb:8:
warning: previous definition of CookieManager was here
```

This adds a guard to make sure that warning does not occur.