### PR TITLE
Use Timeout.timeout instead of Kernel.timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.5
+  - 2.2.3
+  - 2.3.0-preview1
   - ruby-head
   - jruby-18mode
   - jruby-19mode


### PR DESCRIPTION
Because ruby 2.3.0 warns like:

```
.../rbenv/versions/2.3.0-preview2/gemsets/invoice/gems/httpclient-2.7.0.1/lib/httpclient/session.rb:734:in `connect': Object#timeout is deprecated, use Timeout.timeout instead.
```