### PR TITLE
Allow the send+receive timeouts to be updated without reset

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -929,6 +929,11 @@ module HTTP
     # HTTP::Message::Headers:: message header.
     attr_accessor :http_header
 
+    # Request specific send timeout.
+    attr_accessor :http_send_timeout
+    # Request specific receive timeout.
+    attr_accessor :http_receive_timeout
+
     # HTTP::Message::Body:: message body.
     attr_reader :http_body
 

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -1303,12 +1303,47 @@ EOS
     # ToDo
   end
 
+  # this is a dummy body object responding to the Message.file?
+  # interface that simulates a slow send request
+  class SlowBody
+    def initialize(body, sleep)
+      @body = body
+      @sleep = sleep
+    end
+
+    def read(length, outbuf = nil)
+      sleep @sleep # simulate a slow send request
+      outbuf << @body
+      @body.to_s.length
+      nil # EOF, stop reading
+    end
+
+    def pos
+      0 # noop
+    end
+
+    def pos=(v)
+      # noop
+    end
+  end
+
   def test_send_timeout
-    # ToDo
+    # this test takes 4 sec
+    assert_equal('hello?sec=0', @client.post_content(serverurl + 'sleep?sec=0', SlowBody.new('', 0)))
+    @client.send_timeout = 1
+    assert_equal('hello?sec=0', @client.post_content(serverurl + 'sleep?sec=0', SlowBody.new('', 0)))
+    assert_raise(HTTPClient::SendTimeoutError) do
+      @client.post_content(serverurl + 'sleep?sec=2', SlowBody.new('', 2))
+    end
+    @client.send_timeout = 3
+    assert_equal('hello?sec=0', @client.post_content(serverurl + 'sleep?sec=0', SlowBody.new('', 2)))
+    assert_raise(HTTPClient::SendTimeoutError) do
+      @client.post_content(serverurl + 'sleep?sec=2', :body => SlowBody.new('', 2), :timeout => { :send => 1 })
+    end
   end
 
   def test_receive_timeout
-    # this test takes 2 sec
+    # this test takes 4 sec
     assert_equal('hello?sec=2', @client.get_content(serverurl + 'sleep?sec=2'))
     @client.receive_timeout = 1
     assert_equal('hello?sec=0', @client.get_content(serverurl + 'sleep?sec=0'))
@@ -1317,10 +1352,14 @@ EOS
     end
     @client.receive_timeout = 3
     assert_equal('hello?sec=2', @client.get_content(serverurl + 'sleep?sec=2'))
+    assert_raise(HTTPClient::ReceiveTimeoutError) do
+      @client.get_content(serverurl + 'sleep?sec=2', :timeout => { :receive => 1 })
+    end
+    assert_equal('hello?sec=2', @client.get_content(serverurl + 'sleep?sec=2'))
   end
 
   def test_receive_timeout_post
-    # this test takes 2 sec
+    # this test takes 4 sec
     assert_equal('hello', @client.post(serverurl + 'sleep', :sec => 2).content)
     @client.receive_timeout = 1
     assert_equal('hello', @client.post(serverurl + 'sleep', :sec => 0).content)
@@ -1328,6 +1367,10 @@ EOS
       @client.post(serverurl + 'sleep', :sec => 2)
     end
     @client.receive_timeout = 3
+    assert_equal('hello', @client.post(serverurl + 'sleep', :sec => 2).content)
+    assert_raise(HTTPClient::ReceiveTimeoutError) do
+      @client.post(serverurl + 'sleep', :body => { :sec => 2 }, :timeout => { :receive => 1 })
+    end
     assert_equal('hello', @client.post(serverurl + 'sleep', :sec => 2).content)
   end
 


### PR DESCRIPTION
Because we `reset_all` [every time](https://github.com/nahi/httpclient/blob/85b3fcde9a0378e9a219765b0b79b465162b173f/lib/httpclient.rb#L312) an attribute changes on the HTTPClient instance, we lost the keep-alive connection.

This commit allows us to dynamically specify a send and receive timeout per request without reseting the connection and therefore losing the keep-alive.

I tried to keep the coding-style as similar as possible to what you guys did. Let me know what you think and I'll be happy to amend the documentation/README.