### PR TITLE
Silence ruby 2.2 deprecation message

### DIFF
--- a/lib/httpclient/webagent-cookie.rb
+++ b/lib/httpclient/webagent-cookie.rb
@@ -342,7 +342,7 @@ class WebAgent
       cookie.domain_orig = given.domain
       cookie.path_orig = given.path
 
-      if cookie.discard? || nil == cookie.expires
+      if cookie.discard? || cookie.expires.nil?
         cookie.discard = true
       else
         cookie.discard = false

--- a/lib/httpclient/webagent-cookie.rb
+++ b/lib/httpclient/webagent-cookie.rb
@@ -342,7 +342,7 @@ class WebAgent
       cookie.domain_orig = given.domain
       cookie.path_orig = given.path
 
-      if cookie.discard? || cookie.expires == nil
+      if cookie.discard? || nil == cookie.expires
         cookie.discard = true
       else
         cookie.discard = false


### PR DESCRIPTION
Getting this error message in ruby 2.2:

~~~sh
($HOME)/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/httpclient-2.7.1/lib/httpclient/webagent-cookie.rb:345: warning: Comparable#== will no more rescue exceptions of #<=> in the next release.
~~~

Inverting the comparison quickly removes that deprecation message, similar to what was done in https://github.com/rspec/rspec-support/pull/193