### PR TITLE
Use RSA 1024bit CA cert when liked to old openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ notifications:
 
 matrix:
   allow_failures:
-    - rvm: jruby-head # https://github.com/jruby/jruby/issues/3577
+    - rvm: 1.8.7
+    - rvm: jruby-head
     - rvm: rbx-2
     - rvm: jruby-18mode # NoMethodError: undefined method `world_writable?' for #<File::Stat:0x433e0608>

--- a/lib/httpclient/ssl_config.rb
+++ b/lib/httpclient/ssl_config.rb
@@ -204,6 +204,9 @@ class HTTPClient
     #
     # Calling this method resets all existing sessions.
     def add_trust_ca(trust_ca_file_or_hashed_dir)
+      unless File.exist?(trust_ca_file_or_hashed_dir)
+        trust_ca_file_or_hashed_dir = File.join(File.dirname(__FILE__), trust_ca_file_or_hashed_dir)
+      end
       @cacerts_loaded = true # avoid lazy override
       add_trust_ca_to_store(@cert_store, trust_ca_file_or_hashed_dir)
       @cert_store_items << trust_ca_file_or_hashed_dir
@@ -447,7 +450,6 @@ class HTTPClient
           (ver.start_with?('OpenSSL ') && ver >= 'OpenSSL 1.0.2d') || defined?(JRuby)
         filename = 'cacert.pem'
       else
-        warning("RSA 1024 bit CA certificates are loaded due to old openssl compatibility")
         filename = 'cacert1024.pem'
       end
       file = File.join(File.dirname(__FILE__), filename)


### PR DESCRIPTION
Based on comments to #297 this commit silently (without warning) accepts
RSA 1024bit certificate set when runtime ruby is liked with old OpenSSL
(<1.0.1p or <1.0.2d.)

If you're unsure that your OpenSSL is patched or not, and want to make
sure to use RSA 2048bit certificate set, please call
`HTTPClient::SSLConfig#add_trust_ca("cacert.pem")`.

```
c = HTTPClient.new { |c| c.ssl_config.add_trust_ca("cacert.pem") }
c.get("https://www.ruby-lang.org/")
```

I'm going to remove RSA 1024bit certificate set and bump httpclient
version to 2.8.0 soon after I release this as 2.7.2. I believe almost
all OpenSSL installation is patched quickly these days so it should not
cause SSL connectivity problem.

I'm sorry for confusion this warning caused.