### PR TITLE
Force using RSA 2048bit CA cert set

### DIFF
--- a/lib/httpclient/ssl_config.rb
+++ b/lib/httpclient/ssl_config.rb
@@ -441,18 +441,10 @@ class HTTPClient
       nil
     end
 
-    # Use 2014 bit certs trust anchor if possible.
-    # CVE-2015-1793 requires: OpenSSL >= 1.0.2d or OpenSSL >= 1.0.1p
-    # OpenSSL before 1.0.1 does not have CVE-2015-1793 problem
+    # Use 2048 bit certs trust anchor
     def load_cacerts(cert_store)
       ver = OpenSSL::OPENSSL_VERSION
-      if (ver.start_with?('OpenSSL 1.0.1') && ver >= 'OpenSSL 1.0.1p') ||
-          (ver.start_with?('OpenSSL ') && ver >= 'OpenSSL 1.0.2d') || defined?(JRuby)
-        filename = 'cacert.pem'
-      else
-        filename = 'cacert1024.pem'
-      end
-      file = File.join(File.dirname(__FILE__), filename)
+      file = File.join(File.dirname(__FILE__), 'cacert.pem')
       unless defined?(JRuby)
         # JRuby uses @cert_store_items
         add_trust_ca_to_store(cert_store, file)


### PR DESCRIPTION
Use RSA 204bit CA cert set every time if it runs with OpenSSL (== except
JRuby.)

Old openssl (<1.0.1p or <1.0.2d) cannot handle this CA set and causes
SSL connection failure against some SSL servers including AWS S3 API.
For such case you can manually specify RSA 1024bit CA cert set as a
workaround.

```
c = HTTPClient.new { |c| c.ssl_config.add_trust_ca("cacert1024.pem") }
c.get("https://www.ruby-lang.org/")
```

RSA 1024bit CA cert set is not maintained over years so you should
consider updating OpenSSL version so that HTTPClient uses RSA 2048 bit
CA cert set.