### PR TITLE
Fix blocking issue with request_async when Encoding.default_internal is set

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -1270,6 +1270,7 @@ private
       return
     end
     piper, pipew = IO.pipe
+    pipew.binmode
     res = HTTP::Message.new_response(piper, req.header)
     @debug_dev << "= Request\n\n" if @debug_dev
     sess = @session_manager.query(req, proxy)

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -765,6 +765,22 @@ EOS
     assert_equal(1000*1000, res.content.read.length)
   end
 
+  if RUBY_VERSION > "1.9"
+    def test_post_async_with_default_internal
+      original_encoding = Encoding.default_internal
+      Encoding.default_internal = Encoding::UTF_8
+      begin
+        post_body = StringIO.new("こんにちは")
+        conn = @client.post_async(serverurl + 'servlet', post_body)
+        Thread.pass while !conn.finished?
+        res = conn.pop
+        assert_equal 'post,こんにちは', res.content.read
+      ensure
+        Encoding.default_internal = original_encoding
+      end
+    end
+  end
+
   def test_get_with_block
     called = false
     res = @client.get(serverurl + 'servlet') { |str|


### PR DESCRIPTION
In Ruby 2.2 and JRuby 9000 (tested on ruby-2.2.2 and juby-9.0.5.0), when Encoding.default_internal is set to non-nil (which is UTF-8 by default when using Rails) and use HTTPClient#request_async or any other async methods, calling connection.pop.read may block forever.

This happens when there is no charset set in the response header, and when there are any non-ascii characters in the response body. It fails to convert encoding when calling pipew.write(part) in #do_get_stream method.
 
Calling #binmode on write_io of the pipe suppresses encoding conversion.
