### PR TITLE
Add MIME type for XML

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -808,6 +808,8 @@ module HTTP
         case path
         when /\.txt$/i
           'text/plain'
+        when /\.xml$/i
+          'text/xml'
         when /\.(htm|html)$/i
           'text/html'
         when /\.doc$/i


### PR DESCRIPTION
When a XML file is posted, mime type is 'application/octet-stream'.
So I added 'text/xml' to internal_mime_type(path).