### PR TITLE
Revert "Do not reset keep-alive connection by configuration"

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -309,6 +309,7 @@ class HTTPClient
       if assignable
         aname = name + '='
         define_method(aname) { |rhs|
+          reset_all
           @session_manager.__send__(aname, rhs)
         }
       end
@@ -555,22 +556,29 @@ class HTTPClient
   #
   #   clnt.set_auth('http://www.example.com/foo/', 'foo_user', 'passwd')
   #   clnt.set_auth('http://www.example.com/bar/', 'bar_user', 'passwd')
+  #
+  # Calling this method resets all existing sessions.
   def set_auth(domain, user, passwd)
     uri = to_resource_url(domain)
     @www_auth.set_auth(uri, user, passwd)
+    reset_all
   end
 
   # Deprecated.  Use set_auth instead.
   def set_basic_auth(domain, user, passwd)
     uri = to_resource_url(domain)
     @www_auth.basic_auth.set(uri, user, passwd)
+    reset_all
   end
 
   # Sets credential for Proxy authentication.
   # user:: username String.
   # passwd:: password String.
+  #
+  # Calling this method resets all existing sessions.
   def set_proxy_auth(user, passwd)
     @proxy_auth.set_auth(user, passwd)
+    reset_all
   end
 
   # Turn on/off the BasicAuth force flag. Generally HTTP client must

--- a/test/test_http-access2.rb
+++ b/test/test_http-access2.rb
@@ -347,13 +347,11 @@ class TestClient < Test::Unit::TestCase
   def test_receive_timeout
     # this test takes 2 sec
     assert_equal('hello', @client.get_content(serverurl + 'sleep?sec=2'))
-    @client.reset_all
     @client.receive_timeout = 1
     assert_equal('hello', @client.get_content(serverurl + 'sleep?sec=0'))
     assert_raise(HTTPClient::ReceiveTimeoutError) do
       @client.get_content(serverurl + 'sleep?sec=2')
     end
-    @client.reset_all
     @client.receive_timeout = 3
     assert_equal('hello', @client.get_content(serverurl + 'sleep?sec=2'))
   end

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -609,12 +609,10 @@ EOS
     assert_not_equal('hello', content)
     assert_equal(GZIP_CONTENT, content)
     @client.transparent_gzip_decompression = true
-    @client.reset_all
     assert_equal('hello', @client.get_content(serverurl + 'compressed?enc=gzip'))
     assert_equal('hello', @client.get_content(serverurl + 'compressed?enc=deflate'))
     assert_equal('hello', @client.get_content(serverurl + 'compressed?enc=deflate_noheader'))
     @client.transparent_gzip_decompression = false
-    @client.reset_all
   end
 
   def test_get_content_with_block
@@ -1357,13 +1355,11 @@ EOS
     # this test takes 2 sec
     assert_equal('hello?sec=2', @client.get_content(serverurl + 'sleep?sec=2'))
     @client.receive_timeout = 1
-    @client.reset_all
     assert_equal('hello?sec=0', @client.get_content(serverurl + 'sleep?sec=0'))
     assert_raise(HTTPClient::ReceiveTimeoutError) do
       @client.get_content(serverurl + 'sleep?sec=2')
     end
     @client.receive_timeout = 3
-    @client.reset_all
     assert_equal('hello?sec=2', @client.get_content(serverurl + 'sleep?sec=2'))
   end
 
@@ -1371,13 +1367,11 @@ EOS
     # this test takes 2 sec
     assert_equal('hello', @client.post(serverurl + 'sleep', :sec => 2).content)
     @client.receive_timeout = 1
-    @client.reset_all
     assert_equal('hello', @client.post(serverurl + 'sleep', :sec => 0).content)
     assert_raise(HTTPClient::ReceiveTimeoutError) do
       @client.post(serverurl + 'sleep', :sec => 2)
     end
     @client.receive_timeout = 3
-    @client.reset_all
     assert_equal('hello', @client.post(serverurl + 'sleep', :sec => 2).content)
   end
 


### PR DESCRIPTION
Reverts nahi/httpclient#313

After rethinking, I found making auth as session local configuration is not good. It introduces race condition because it's shared configuration across requests in compared to the fact that connection configurations are not shared across sessions. I'll remove auth part changes.