### PR TITLE
Do not reset keep-alive connection by configuration

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -309,7 +309,6 @@ class HTTPClient
       if assignable
         aname = name + '='
         define_method(aname) { |rhs|
-          reset_all
           @session_manager.__send__(aname, rhs)
         }
       end

--- a/test/test_http-access2.rb
+++ b/test/test_http-access2.rb
@@ -347,11 +347,13 @@ class TestClient < Test::Unit::TestCase
   def test_receive_timeout
     # this test takes 2 sec
     assert_equal('hello', @client.get_content(serverurl + 'sleep?sec=2'))
+    @client.reset_all
     @client.receive_timeout = 1
     assert_equal('hello', @client.get_content(serverurl + 'sleep?sec=0'))
     assert_raise(HTTPClient::ReceiveTimeoutError) do
       @client.get_content(serverurl + 'sleep?sec=2')
     end
+    @client.reset_all
     @client.receive_timeout = 3
     assert_equal('hello', @client.get_content(serverurl + 'sleep?sec=2'))
   end

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -609,10 +609,12 @@ EOS
     assert_not_equal('hello', content)
     assert_equal(GZIP_CONTENT, content)
     @client.transparent_gzip_decompression = true
+    @client.reset_all
     assert_equal('hello', @client.get_content(serverurl + 'compressed?enc=gzip'))
     assert_equal('hello', @client.get_content(serverurl + 'compressed?enc=deflate'))
     assert_equal('hello', @client.get_content(serverurl + 'compressed?enc=deflate_noheader'))
     @client.transparent_gzip_decompression = false
+    @client.reset_all
   end
 
   def test_get_content_with_block
@@ -1355,11 +1357,13 @@ EOS
     # this test takes 2 sec
     assert_equal('hello?sec=2', @client.get_content(serverurl + 'sleep?sec=2'))
     @client.receive_timeout = 1
+    @client.reset_all
     assert_equal('hello?sec=0', @client.get_content(serverurl + 'sleep?sec=0'))
     assert_raise(HTTPClient::ReceiveTimeoutError) do
       @client.get_content(serverurl + 'sleep?sec=2')
     end
     @client.receive_timeout = 3
+    @client.reset_all
     assert_equal('hello?sec=2', @client.get_content(serverurl + 'sleep?sec=2'))
   end
 
@@ -1367,11 +1371,13 @@ EOS
     # this test takes 2 sec
     assert_equal('hello', @client.post(serverurl + 'sleep', :sec => 2).content)
     @client.receive_timeout = 1
+    @client.reset_all
     assert_equal('hello', @client.post(serverurl + 'sleep', :sec => 0).content)
     assert_raise(HTTPClient::ReceiveTimeoutError) do
       @client.post(serverurl + 'sleep', :sec => 2)
     end
     @client.receive_timeout = 3
+    @client.reset_all
     assert_equal('hello', @client.post(serverurl + 'sleep', :sec => 2).content)
   end
 


### PR DESCRIPTION
Reverts nahi/httpclient#314

Connection configuration change should not require 'reset_all' call to
terminate all existing connections because thoese connections are
already living with the old configuration. Resetting all connection on
such configuration update is good to make all sessions have the same
configuration, it's simpler to understand, but as #295 describes it
sometimes make keep-alive connection meaningless. (Setting timeout
always closes all keep-alive connections every time.)

By this commit following configuration update does NOT reset keep-alive

* Session manager configurations
  * protocol_version
  * connect_timeout
  * send_timeout
  * receive_timeout
  * keep_alive_timeout
  * read_block_size
  * protocol_retry_count
  * socket_sync
  * agent_name
  * from
  * transparent_gzip_decompression
  * socket_local

As I also needed to update, test scripts should be careful about
keep-alive connections...