### PR TITLE
Add strict_response_size_check option

### DIFF
--- a/bin/httpclient
+++ b/bin/httpclient
@@ -20,6 +20,7 @@ end
 url = ARGV.shift
 if method && url
   client = HTTPClient.new
+  client.strict_response_size_check = true
   if method == 'download'
     print client.get_content(url)
   else
@@ -37,6 +38,7 @@ require 'irb/completion'
 class Runner
   def initialize
     @httpclient = HTTPClient.new
+    @httpclient.strict_response_size_check = true
   end
 
   def method_missing(msg, *a, &b)

--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -364,6 +364,9 @@ class HTTPClient
   attr_proxy(:test_loopback_http_response)
   # Decompress a compressed (with gzip or deflate) content body transparently. false by default.
   attr_proxy(:transparent_gzip_decompression, true)
+  # Raise BadResponseError if response size does not match with Content-Length header in response. false by default.
+  # TODO: enable by default
+  attr_proxy(:strict_response_size_check, true)
   # Local socket address. Set HTTPClient#socket_local.host and HTTPClient#socket_local.port to specify local binding hostname and port of TCP socket.
   attr_proxy(:socket_local, true)
 

--- a/lib/oauthclient.rb
+++ b/lib/oauthclient.rb
@@ -33,6 +33,7 @@ class OAuthClient < HTTPClient
     @oauth_config = HTTPClient::OAuth::Config.new
     self.www_auth.oauth.set_config(nil, @oauth_config)
     self.www_auth.oauth.challenge(nil)
+    self.strict_response_size_check = true
   end
 
   # Get request token.

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -1830,6 +1830,19 @@ EOS
     end
   end
 
+  def test_strict_response_size_check
+    @client.strict_response_size_check = false
+    @client.test_loopback_http_response << "HTTP/1.0 200 OK\r\nContent-Length: 12345\r\n\r\nhello world"
+    assert_equal('hello world', @client.get_content('http://dummy'))
+
+    @client.reset_all
+    @client.strict_response_size_check = true
+    @client.test_loopback_http_response << "HTTP/1.0 200 OK\r\nContent-Length: 12345\r\n\r\nhello world"
+    assert_raise(HTTPClient::BadResponseError) do
+      @client.get_content('http://dummy')
+    end
+  end
+
   def test_socket_local
     @client.socket_local.host = '127.0.0.1'
     assert_equal('hello', @client.get_content(serverurl + 'hello'))


### PR DESCRIPTION
An option to raise BadResponse if response size does not match with
Content-Length header in response.

Currently HTTPClient ignores response size even if the size does not
match.  Perhaps because of bad HTTP servers, browsers ignore EOF even for
file download (simple GET.).

https://code.google.com/p/chromium/codesearch#chromium/src/content/browser/download/download_request_core.cc&q=ERR_INCOMPLETE_CHUNKED_ENCODING&sq=package:chromium&type=cs&l=534
Chromium seems to ignore incomplete download (both for
ERR_CONTENT_LENGTH_MISMATCH and ERR_INCOMPLETE_CHUNKED_ENCODING) for
download.

https://bugzilla.mozilla.org/show_bug.cgi?id=237623
The comment in this issue says the newer Firefox detects EOF but I
confirmed that Firefox also ignores EOF.

httpclient is not a browser so it should not suppress EOFError but I
also worry about incompatible behavior with previous versions. So this
commit adds an option but it's disabled by default.  In the next version
update I'll enable this.