### PR TITLE
Direct access to SSLConfig#cert_store in JRuby was broken from 2.7

### DIFF
--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -151,6 +151,20 @@ end
     assert_equal("hello", @client.get_content(@url))
   end
 
+  def test_cert_store
+    cfg = @client.ssl_config
+    cfg.cert_store.add_cert(cert('ca.cert'))
+    begin
+      @client.get(@url)
+      assert(false)
+    rescue OpenSSL::SSL::SSLError => ssle
+      assert_match(/(certificate verify failed|unable to find valid certification path to requested target)/, ssle.message)
+    end
+    #
+    cfg.cert_store.add_cert(cert('subca.cert'))
+    assert_equal("hello", @client.get_content(@url))
+  end
+
 if defined?(HTTPClient::JRubySSLSocket)
   def test_ciphers
     cfg = @client.ssl_config


### PR DESCRIPTION
JRubySSLSocket needs to access included PEM files of X509::Store for
initializing Java's SSL configurations but OpenSSL::X509::Store does not
provide the list of loaded certificates. So this commit wraps an
instance and remembers certificates in it.