### PR TITLE
CA certs ignored by 2.8.1 when a file has multiple PEMs

### DIFF
--- a/lib/httpclient/jruby_ssl_socket.rb
+++ b/lib/httpclient/jruby_ssl_socket.rb
@@ -316,6 +316,7 @@ unless defined?(SSLSocket)
         return if cert_source == :default
         if cert_source.respond_to?(:to_pem)
           pem = cert_source.to_pem
+          load_pem(pem)
         elsif File.directory?(cert_source)
           warn("#{cert_source}: directory not yet supported")
           return
@@ -326,7 +327,8 @@ unless defined?(SSLSocket)
             when /-----BEGIN CERTIFICATE-----/
               pem = ''
             when /-----END CERTIFICATE-----/
-              break
+              load_pem(pem)
+              # keep parsing in case where multiple certificates in a file
             else
               if pem
                 pem << line
@@ -334,9 +336,6 @@ unless defined?(SSLSocket)
             end
           end
         end
-        cert = PEMUtils.read_certificate(pem)
-        @size += 1
-        @trust_store.setCertificateEntry("cert_#{@size}", cert)
       end
 
       def trust_store
@@ -345,6 +344,14 @@ unless defined?(SSLSocket)
         else
           @trust_store
         end
+      end
+
+    private
+
+      def load_pem(pem)
+        cert = PEMUtils.read_certificate(pem)
+        @size += 1
+        @trust_store.setCertificateEntry("cert_#{@size}", cert)
       end
     end
 

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -217,18 +217,14 @@ else
   end
 end
 
-  # SSL_CERT_FILE does not work with recent jruby-openssl.
-  # You should not depend on SSL_CERT_FILE on JRuby
-  if !defined?(JRUBY_VERSION)
-    def test_set_default_paths
-      assert_raise(OpenSSL::SSL::SSLError) do
-        @client.get(@url)
-      end
-      escape_env do
-        ENV['SSL_CERT_FILE'] = File.join(DIR, 'ca-chain.pem')
-        @client.ssl_config.set_default_paths
-        @client.get(@url)
-      end
+  def test_set_default_paths
+    assert_raise(OpenSSL::SSL::SSLError) do
+      @client.get(@url)
+    end
+    escape_env do
+      ENV['SSL_CERT_FILE'] = File.join(DIR, 'ca-chain.pem')
+      @client.ssl_config.set_default_paths
+      @client.get(@url)
     end
   end
 


### PR DESCRIPTION
The bug was introduced at 2.8.1. This should fix #322.