### PR TITLE
Followup fix for #325

### DIFF
--- a/lib/httpclient/session.rb
+++ b/lib/httpclient/session.rb
@@ -21,7 +21,7 @@ require 'zlib'
 require 'httpclient/timeout' # TODO: remove this once we drop 1.8 support
 require 'httpclient/ssl_config'
 require 'httpclient/http'
-if defined?(JRuby)
+if RUBY_ENGINE == 'jruby'
   require 'httpclient/jruby_ssl_socket'
 else
   require 'httpclient/ssl_socket'


### PR DESCRIPTION
The change #323 wrongly overwrote X509::Store#initialize and broke non
httpclient code. #325 fixed this problem (Thanks @abrandoned!) but I
found that #323 has another problem that add_cert, add_file and add_path
share the same `wrapped` local variable. It was calling add_path at
super call in add_cert. In the case user overrides add_cert or add_file
it does not call proper method.

We can just use Module.prepend for this purpose but httpclient still
supports JRuby1.7 + 1.9 so this time I keep using my custom "prepend"
implementation. Once we dropped JRuby 1.7 support I should replease this
code with Module.prepend.