### PR TITLE
Socket: Avoid frozen string errors on Ruby 2.3

### DIFF
--- a/lib/httpclient/session.rb
+++ b/lib/httpclient/session.rb
@@ -76,7 +76,7 @@ class HTTPClient
     def to_s # :nodoc:
       addr
     end
-    
+
     # Returns true if scheme, host and port of the given URI matches with this.
     def match(uri)
       (@scheme == uri.scheme) and (@host == uri.host) and (@port == uri.port.to_i)
@@ -612,11 +612,9 @@ class HTTPClient
           socket.debug_dev = @debug_dev
         end
       rescue SystemCallError => e
-        e.message << " (#{host}:#{port})"
-        raise
+        raise e.class, e.message + " (#{host}:#{port})"
       rescue SocketError => e
-        e.message << " (#{host}:#{port})"
-        raise
+        raise e.class, e.message + " (#{host}:#{port})"
       end
       socket
     end


### PR DESCRIPTION
On Ruby 2.3, the message from SocketError may be a frozen string.  In this case, `e.message << "..."` will fail as this string cannot be modified.  Instead, just raise a new exception with an explicit concatenation of strings for the message.

Please let me know if I can provide additional help / context regarding this error.  Thank you!