### PR TITLE
⚠️ assigned but unused variable - ver

### DIFF
--- a/lib/httpclient/ssl_config.rb
+++ b/lib/httpclient/ssl_config.rb
@@ -471,7 +471,6 @@ class HTTPClient
 
     # Use 2048 bit certs trust anchor
     def load_cacerts(cert_store)
-      ver = OpenSSL::OPENSSL_VERSION
       file = File.join(File.dirname(__FILE__), 'cacert.pem')
       add_trust_ca_to_store(cert_store, file)
     end


### PR DESCRIPTION
This eliminates a Ruby warning "warning: assigned but unused variable - ver".

Actually we get another warning as follows:
```
gems/httpclient-2.8.2.4/lib/httpclient/ssl_config.rb:51: warning: method redefined; discarding old initialize
gems/httpclient-2.8.2.4/lib/httpclient/ssl_config.rb:58: warning: method redefined; discarding old add_cert
gems/httpclient-2.8.2.4/lib/httpclient/ssl_config.rb:58: warning: method redefined; discarding old add_file
gems/httpclient-2.8.2.4/lib/httpclient/ssl_config.rb:58: warning: method redefined; discarding old add_path
```
but as I can see [a TODO comment](https://github.com/nahi/httpclient/blob/f7b36d2257407dfbb807ab004c144b5a991ac5b1/lib/httpclient/ssl_config.rb#L47) above that code already, I'll just leave it as is.