### PR TITLE
ruby-head + rdoc has dependency problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ notifications:
 
 matrix:
   allow_failures:
+    - rvm: ruby-head
     - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,6 @@ group :development do
   gem 'rubysspi'
   gem 'rubyntlm'
   gem 'rack-ntlm-test-service'
-  if RUBY_VERSION >= '2.4'
-    gem 'json', '~> 2.0'
-  end
 end
 
 gemspec


### PR DESCRIPTION
RDoc 4.x requires json 1.x which is not compatible with ruby >= 2.4