### PR TITLE
allow JSONClient to auto-serialize an Array

### DIFF
--- a/lib/jsonclient.rb
+++ b/lib/jsonclient.rb
@@ -37,7 +37,7 @@ private
 
   def argument_to_hash_for_json(args)
     hash = argument_to_hash(args, :body, :header, :follow_redirect)
-    if hash[:body].is_a?(Hash)
+    if hash[:body].is_a?(Hash) || hash[:body].is_a?(Array)
       hash[:header] = json_header(hash[:header])
       hash[:body] = JSON.generate(hash[:body])
     end

--- a/test/test_jsonclient.rb
+++ b/test/test_jsonclient.rb
@@ -24,6 +24,14 @@ class TestJSONClient < Test::Unit::TestCase
     assert_equal(1, JSON.parse(res.previous.content)['a'])
   end
 
+  def test_post_with_array
+    res = @client.post(serverurl + 'json', [{'a' => 1}, {'b' => {'c' => 2}}])
+    assert_equal(2, res.content[1]['b']['c'])
+    assert_equal('application/json; charset=utf-8', res.content_type)
+    # #previous contains the original response
+    assert_equal(1, JSON.parse(res.previous.content)[0]['a'])
+  end
+
   def test_post_with_header
     res = @client.post(serverurl + 'json', :header => {'X-foo' => 'bar'}, :body => {'a' => 1, 'b' => {'c' => 2}})
     assert_equal(2, res.content['b']['c'])


### PR DESCRIPTION
Allows JSONClient requests where the data payload is an Array. Some APIs require data in this format.

Example request:
`JSONClient.put("http://example.com/hi.json", [{'a' => 1}, {'b' => {'c' => 2}}])`