### PR TITLE
Check jruby a different way

### DIFF
--- a/lib/httpclient/session.rb
+++ b/lib/httpclient/session.rb
@@ -21,7 +21,7 @@ require 'zlib'
 require 'httpclient/timeout' # TODO: remove this once we drop 1.8 support
 require 'httpclient/ssl_config'
 require 'httpclient/http'
-if RUBY_ENGINE == 'jruby'
+if defined? JRUBY_VERSION
   require 'httpclient/jruby_ssl_socket'
 else
   require 'httpclient/ssl_socket'


### PR DESCRIPTION
RUBY_ENGINE is undefined in MRI 1.8.x. Currently httpclient is broken on 1.8, so I think this deserves a merge/release, if you don't mind! I couldn't find any info on officially supported Ruby versions, but keeping compatibility is nice if it's easy.