### PR TITLE
Fix SNI handling for JRuby

### DIFF
--- a/lib/httpclient/jruby_ssl_socket.rb
+++ b/lib/httpclient/jruby_ssl_socket.rb
@@ -549,8 +549,11 @@ unless defined?(SSLSocket)
       if socket
         ssl_socket = factory.createSocket(socket, dest.host, dest.port, true)
       else
-        ssl_socket = factory.createSocket
-        JavaSocketWrap.connect(ssl_socket, dest, opts)
+        # Create a plain socket first to set connection timeouts on,
+        # then wrap it in a SSL socket so that SNI gets setup on it.
+        socket = javax.net.SocketFactory.getDefault.createSocket
+        JavaSocketWrap.connect(socket, dest, opts)
+        ssl_socket = factory.createSocket(socket, dest.host, dest.port, true)
       end
       ssl_socket
     end


### PR DESCRIPTION
Changes to set SSL connection timeout inadvertently broke SNI for
JRuby. This fixes #362 by creating a regular socket first, setting
timeouts on it, then wrapping that socket in a SSLSocet, specifying the
hostname when creating that wrapper socket.

No tests currently, I'm not sure how to test SNI locally.