### PR TITLE
Stop mutating header argument in JSONClient

### DIFF
--- a/lib/jsonclient.rb
+++ b/lib/jsonclient.rb
@@ -47,11 +47,10 @@ private
   def json_header(header)
     header ||= {}
     if header.is_a?(Hash)
-      header['Content-Type'] = @content_type_json_request
+      header.merge('Content-Type' => @content_type_json_request)
     else
-      header << ['Content-Type', @content_type_json_request]
+      header + [['Content-Type', @content_type_json_request]]
     end
-    header
   end
 
   def wrap_json_response(original)

--- a/test/test_jsonclient.rb
+++ b/test/test_jsonclient.rb
@@ -54,6 +54,18 @@ class TestJSONClient < Test::Unit::TestCase
     assert_equal('', res.content_type)
   end
 
+  def test_hash_header_not_modified
+    header = {'X-foo' => 'bar'}
+    res = @client.post(serverurl, :header => header, :body => {'a' => 1, 'b' => {'c' => 2}})
+    assert_equal({'X-foo' => 'bar'}, header)
+  end
+
+  def test_array_header_not_modified
+    header = [['X-foo', 'bar']]
+    res = @client.post(serverurl, :header => header, :body => {'a' => 1, 'b' => {'c' => 2}})
+    assert_equal([['X-foo', 'bar']], header)
+  end
+
   class JSONServlet < WEBrick::HTTPServlet::AbstractServlet
     def get_instance(*arg)
       self


### PR DESCRIPTION
Ran into this when I passed in a frozen hash.