### PR TITLE
raise the cause of KeepAliveDisconnected to caller

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -1136,6 +1136,8 @@ private
       Thread.current[:HTTPClient_AcquireNewConnection] = true
       begin
         yield
+      rescue KeepAliveDisconnected => e
+        raise e.cause || e
       ensure
         Thread.current[:HTTPClient_AcquireNewConnection] = false
       end


### PR DESCRIPTION
It's rarely useful when a caller receives KeepAliveDisconnected
exception.  By this commit caller only receives KeepAliveDisconnected
when HTTPClient receives empty header line twice.

Test should come later.