### PR TITLE
Improve timeout error during jruby ssl connection

### DIFF
--- a/lib/httpclient/jruby_ssl_socket.rb
+++ b/lib/httpclient/jruby_ssl_socket.rb
@@ -491,6 +491,8 @@ unless defined?(SSLSocket)
         ssl_connect(dest.host)
       rescue java.security.GeneralSecurityException => e
         raise OpenSSL::SSL::SSLError.new(e.getMessage)
+      rescue java.javanet.SocketTimeoutException => e
+        raise HTTPClient::ConnectTimeoutError.new(e.getMessage)
       rescue java.io.IOException => e
         raise OpenSSL::SSL::SSLError.new("#{e.class}: #{e.getMessage}")
       end


### PR DESCRIPTION
This fixes #381 by adding explicit handling for
Java::JavaNet::SocketTimeoutException when establishing a JRuby SSL
connection.