### PR TITLE
Surround IPv6 address in `Host` header with brackets

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -399,9 +399,9 @@ module HTTP
         if @http_version >= '1.1' and get('Host').empty?
           if @request_uri.port == @request_uri.default_port
             # GFE/1.3 dislikes default port number (returns 404)
-            set('Host', "#{@request_uri.hostname}")
+            set('Host', "#{@request_uri.host}")
           else
-            set('Host', "#{@request_uri.hostname}:#{@request_uri.port}")
+            set('Host', "#{@request_uri.host}:#{@request_uri.port}")
           end
         end
       end

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -1894,7 +1894,15 @@ EOS
     }
     uri = "http://[::1]:#{server.addr[1]}/"
     begin
-      assert_equal('12345', @client.get(uri).body)
+      str = ""
+      @client.debug_dev = str
+      res = @client.get(uri)
+      assert_equal('12345', res.body)
+      lines = str.split(/(?:\r?\n)+/)
+      assert_equal("= Request", lines[0])
+      assert_equal("! CONNECTION ESTABLISHED", lines[2])
+      assert_equal("GET / HTTP/1.1", lines[3])
+      assert_equal("Host: [::1]:#{server.addr[1]}", lines[7])
     ensure
       server.close
       server_thread.kill


### PR DESCRIPTION
Fixes nahi/httpclient#387.