### PR TITLE
Don't retry PUT and POST requests that fail to complete

### DIFF
--- a/test/test_http-access2.rb
+++ b/test/test_http-access2.rb
@@ -211,9 +211,9 @@ class TestClient < Test::Unit::TestCase
   end
 
   def test_post_content
-    assert_equal('hello', @client.post_content(serverurl + 'hello'))
-    assert_equal('hello', @client.post_content(serverurl + 'redirect1'))
-    assert_equal('hello', @client.post_content(serverurl + 'redirect2'))
+    assert_equal('hello', @client.post_content(serverurl + 'hello', ''))
+    assert_equal('hello', @client.post_content(serverurl + 'redirect1', ''))
+    assert_equal('hello', @client.post_content(serverurl + 'redirect2', ''))
     assert_raises(HTTPClient::Session::BadResponse) do
       @client.post_content(serverurl + 'notfound')
     end
@@ -226,7 +226,7 @@ class TestClient < Test::Unit::TestCase
       called = true
       newuri
     }
-    assert_equal('hello', @client.post_content(serverurl + 'relative_redirect'))
+    assert_equal('hello', @client.post_content(serverurl + 'relative_redirect', ''))
     assert(called)
   end
 


### PR DESCRIPTION
This fixes #142 by not raising a KeepAliveDisconnect error for POST or
PUT requests.  For those methods, the original error is allowed through
instead.  This patch is different from
fd077c7dcbb323353d412249e7b40eae3a00a37f in that persistent connections
are still used for POST and PUT, just not the retry logic.

Also, as a result of removing the retry, I noticed a number of tests
doing 'no content posts' were failing due incorrect behaviour in Webrick
(as per fd077c7dcbb323353d412249e7b40eae3a00a37f).   I have changed the
test cases to be 'empty content posts' instead.