### PR TITLE
Array accepted as a legit JSON object for JSONClient put/post requests

### DIFF
--- a/lib/jsonclient.rb
+++ b/lib/jsonclient.rb
@@ -37,7 +37,7 @@ private
 
   def argument_to_hash_for_json(args)
     hash = argument_to_hash(args, :body, :header, :follow_redirect)
-    if hash[:body].is_a?(Hash)
+    if hash[:body].is_a?(Hash) || hash[:body].is_a?(Array)
       hash[:header] = json_header(hash[:header])
       hash[:body] = JSON.generate(hash[:body])
     end

--- a/test/test_jsonclient.rb
+++ b/test/test_jsonclient.rb
@@ -24,6 +24,12 @@ class TestJSONClient < Test::Unit::TestCase
     assert_equal(1, JSON.parse(res.previous.content)['a'])
   end
 
+  def test_post_with_array
+    res = @client.post(serverurl + 'json', [{'a' => 1, 'b' => {'c' => 2}}])
+    assert_equal(2, res.content[0]['b']['c'])
+    assert_equal('application/json; charset=utf-8', res.content_type)
+  end
+
   def test_post_with_header
     res = @client.post(serverurl + 'json', :header => {'X-foo' => 'bar'}, :body => {'a' => 1, 'b' => {'c' => 2}})
     assert_equal(2, res.content['b']['c'])


### PR DESCRIPTION
Currently, `JSONClient` includes the proper `content-type` headers only for `Hash` body type. Array is also a legit root object for JSON object and therefore support for it is added.

Example:
https://jsonlint.com/?json=%22[%27root_object%27:%20{%27is_valid%27:%20true}]%22