### PR TITLE
Set time in test_verification_without_httpclient test during cert validation

### DIFF
--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -1,5 +1,6 @@
 require File.expand_path('helper', File.dirname(__FILE__))
 require 'webrick/https'
+require 'time'
 
 
 class TestSSL < Test::Unit::TestCase
@@ -87,6 +88,7 @@ end
     cert = ::OpenSSL::X509::Certificate.new(raw_cert)
     store = ::OpenSSL::X509::Store.new
     store.add_cert(ca_cert)
+    store.time = Time.new(2017, 01, 01)
     assert(store.verify(cert))
   end
 


### PR DESCRIPTION
Certificates are hard coded in the test_verification_without_httpclient function.

The CA Cert will expire in August 2018, the cert being tested expired in August 2017.

This will set the time used to perform the verification so the certs in this test do not need to be updated due to expiration.

This *should* make the check failures in #388 happy (+1 for that PR)