### PR TITLE
Fix error in lib/httpclient/util.rb when frozen strings are enabled

### DIFF
--- a/lib/hexdump.rb
+++ b/lib/hexdump.rb
@@ -11,7 +11,7 @@ module HexDump
     result = []
     while raw = str.slice(offset, 16) and raw.length > 0
       # data field
-      data = ''
+      data = ''.dup
       for v in raw.unpack('N* a*')
 	if v.kind_of? Integer
 	  data << sprintf("%08x ", v)

--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -1236,7 +1236,7 @@ private
       conn.push(res)
       return res
     end
-    content = block ? nil : ''
+    content = block ? nil : ''.dup
     res = HTTP::Message.new_response(content, req.header)
     @debug_dev << "= Request\n\n" if @debug_dev
     sess = @session_manager.query(req, proxy)

--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -238,7 +238,7 @@ module HTTP
       if defined?(Encoding::ASCII_8BIT)
         def set_body_encoding
           if type = self.content_type
-            OpenURI::Meta.init(o = '')
+            OpenURI::Meta.init(o = ''.dup)
             o.meta_add_field('content-type', type)
             @body_encoding = o.encoding
           end
@@ -491,7 +491,7 @@ module HTTP
       # String.
       #
       # assert: @size is not nil
-      def dump(header = '', dev = '')
+      def dump(header = '', dev = ''.dup)
         if @body.is_a?(Parts)
           dev << header
           @body.parts.each do |part|
@@ -521,7 +521,7 @@ module HTTP
       # reason. (header is dumped to dev, too)
       # If no dev (the second argument) given, this method returns a dumped
       # String.
-      def dump_chunked(header = '', dev = '')
+      def dump_chunked(header = '', dev = ''.dup)
         dev << header
         if @body.is_a?(Parts)
           @body.parts.each do |part|
@@ -574,7 +574,7 @@ module HTTP
       end
 
       def dump_file(io, dev, sz)
-        buf = ''
+        buf = ''.dup
         rest = sz
         while rest > 0
           n = io.read([rest, @chunk_size].min, buf)
@@ -954,7 +954,7 @@ module HTTP
 
     # Dumps message (header and body) to given dev.
     # dev needs to respond to <<.
-    def dump(dev = '')
+    def dump(dev = ''.dup)
       str = @http_header.dump + CRLF
       if @http_header.chunked
         dev = @http_body.dump_chunked(str, dev)

--- a/lib/httpclient/session.rb
+++ b/lib/httpclient/session.rb
@@ -951,7 +951,7 @@ class HTTPClient
 
     def empty_bin_str
       str = ''
-      str.force_encoding('BINARY') if str.respond_to?(:force_encoding)
+      str = str.dup.force_encoding('BINARY') if str.respond_to?(:force_encoding)
       str
     end
   end

--- a/lib/httpclient/util.rb
+++ b/lib/httpclient/util.rb
@@ -64,7 +64,7 @@ class HTTPClient
         # Overwrites the original definition just for one line...
         def authority
           self.host && @authority ||= (begin
-            authority = ""
+            authority = "".dup
             if self.userinfo != nil
               authority << "#{self.userinfo}@"
             end

--- a/test/test_auth.rb
+++ b/test/test_auth.rb
@@ -249,7 +249,7 @@ class TestAuth < Test::Unit::TestCase
     c.set_auth("http://localhost:#{serverport}/", 'admin', 'admin')
     assert_equal('basic_auth OK', c.get_content("http://localhost:#{serverport}/basic_auth/"))
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content("http://localhost:#{serverport}/basic_auth/sub/dir/")
     assert_match(/Authorization: Basic YWRtaW46YWRtaW4=/, str)
   end
@@ -265,7 +265,7 @@ class TestAuth < Test::Unit::TestCase
     c.set_auth("http://localhost:#{serverport}/", 'admin', 'admin')
     assert_equal('digest_auth OK', c.get_content("http://localhost:#{serverport}/digest_auth/"))
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content("http://localhost:#{serverport}/digest_auth/sub/dir/")
     assert_match(/Authorization: Digest/, str)
   end
@@ -311,7 +311,7 @@ class TestAuth < Test::Unit::TestCase
     c.set_auth('http://example.com/', 'admin', 'admin')
     c.test_loopback_http_response << "HTTP/1.0 401 Unauthorized\nWWW-Authenticate: Basic realm=\"foo\"\nWWW-Authenticate: Digest realm=\"foo\", nonce=\"nonce\", stale=false\nContent-Length: 2\n\nNG"
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content('http://example.com/')
     assert_match(/^Authorization: Digest/, str)
   end
@@ -327,7 +327,7 @@ class TestAuth < Test::Unit::TestCase
     c.set_proxy_auth('admin', 'admin')
     c.test_loopback_http_response << "HTTP/1.0 407 Unauthorized\nProxy-Authenticate: Basic realm=\"foo\"\nContent-Length: 2\n\nNG"
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content('http://example.com/')
     assert_match(/Proxy-Authorization: Basic YWRtaW46YWRtaW4=/, str)
   end
@@ -337,7 +337,7 @@ class TestAuth < Test::Unit::TestCase
     c.set_proxy_auth('admin', 'admin')
     c.force_basic_auth = true
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content('http://example.com/')
     assert_match(/Proxy-Authorization: Basic YWRtaW46YWRtaW4=/, str)
   end
@@ -349,7 +349,7 @@ class TestAuth < Test::Unit::TestCase
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
     c.get_content('http://www1.example.com/')
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content('http://www2.example.com/')
     assert_match(/Proxy-Authorization: Basic YWRtaW46YWRtaW4=/, str)
   end
@@ -363,7 +363,7 @@ class TestAuth < Test::Unit::TestCase
     ha1 = md5.hexdigest("admin:foo:admin")
     ha2 = md5.hexdigest("GET:/")
     response = md5.hexdigest("#{ha1}:nonce:#{ha2}")
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content('http://example.com/')
     assert_match(/Proxy-Authorization: Digest/, str)
     assert_match(%r"response=\"#{response}\"", str)
@@ -394,7 +394,7 @@ class TestAuth < Test::Unit::TestCase
     ha1 = md5.hexdigest("admin:foo:admin")
     ha2 = md5.hexdigest("GET:/")
     response = md5.hexdigest("#{ha1}:nonce:#{ha2}")
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content('http://example.com/')
     assert_match(/Proxy-Authorization: Digest/, str)
     assert_match(%r"response=\"#{response}\"", str)
@@ -411,7 +411,7 @@ class TestAuth < Test::Unit::TestCase
     ha2 = md5.hexdigest("GET:/")
     response = md5.hexdigest("#{ha1}:nonce:#{ha2}")
     c.get_content('http://www1.example.com/')
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content('http://www2.example.com/')
     assert_match(/Proxy-Authorization: Digest/, str)
     assert_match(%r"response=\"#{response}\"", str)
@@ -433,19 +433,19 @@ class TestAuth < Test::Unit::TestCase
     c.www_auth.oauth.set_config('http://photos.example.net/', config)
     c.www_auth.oauth.challenge('http://photos.example.net/')
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content('http://photos.example.net/photos', [[:file, 'vacation.jpg'], [:size, 'original']])
     assert(str.index(%q(GET /photos?file=vacation.jpg&size=original)))
     assert(str.index(%q(Authorization: OAuth realm="http://photos.example.net/", oauth_consumer_key="dpf43f3p2l4k3l03", oauth_nonce="kllo9940pd9333jh", oauth_signature="tR3%2BTy81lMeYAr%2FFid0kMTYa%2FWM%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1191242096", oauth_token="nnch734d00sl2jdk", oauth_version="1.0")))
     #
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get_content('http://photos.example.net/photos?file=vacation.jpg&size=original')
     assert(str.index(%q(GET /photos?file=vacation.jpg&size=original)))
     assert(str.index(%q(Authorization: OAuth realm="http://photos.example.net/", oauth_consumer_key="dpf43f3p2l4k3l03", oauth_nonce="kllo9940pd9333jh", oauth_signature="tR3%2BTy81lMeYAr%2FFid0kMTYa%2FWM%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1191242096", oauth_token="nnch734d00sl2jdk", oauth_version="1.0")))
     #
     c.test_loopback_http_response << "HTTP/1.0 200 OK\nContent-Length: 2\n\nOK"
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.post_content('http://photos.example.net/photos', [[:file, 'vacation.jpg'], [:size, 'original']])
     assert(str.index(%q(POST /photos)))
     assert(str.index(%q(Authorization: OAuth realm="http://photos.example.net/", oauth_consumer_key="dpf43f3p2l4k3l03", oauth_nonce="kllo9940pd9333jh", oauth_signature="wPkvxykrw%2BBTdCcGqKr%2B3I%2BPsiM%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1191242096", oauth_token="nnch734d00sl2jdk", oauth_version="1.0")))
@@ -475,7 +475,7 @@ class TestAuth < Test::Unit::TestCase
     c.test_loopback_http_response << %Q(HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: NTLM TlRMTVNTUAACAAAAAAAAACgAAAABAAAAAAAAAAAAAAA=\r\nConnection: Keep-Alive\r\nContent-Length: 0\r\n\r\n)
     c.test_loopback_http_response << %Q(HTTP/1.0 200 OK\r\nConnection: Keep-Alive\r\nContent-Length: 1\r\n\r\na)
     c.test_loopback_http_response << %Q(HTTP/1.0 200 OK\r\nConnection: Keep-Alive\r\nContent-Length: 1\r\n\r\nb)
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.set_auth('http://www.example.org/', 'admin', 'admin')
     # Do NTLM negotiation
     c.get('http://www.example.org/foo')
@@ -484,7 +484,7 @@ class TestAuth < Test::Unit::TestCase
     assert_match(%r(Authorization: NTLM), str)
     assert_not_match(%r(Authorization: Basic), str)
     # ditto for other resource that is protected with NTLM
-    c.debug_dev = str = ''
+    c.debug_dev = str = ''.dup
     c.get('http://www.example.org/foo/subdir')
     assert_not_match(%r(Authorization: NTLM), str)
     assert_not_match(%r(Authorization: Basic), str)

--- a/test/test_hexdump.rb
+++ b/test/test_hexdump.rb
@@ -5,7 +5,7 @@ require 'hexdump'
 
 class TestHexDump < Test::Unit::TestCase
   def test_encode
-    str = "\032l\277\370\2429\216\236\351[{\{\262\350\274\376"
+    str = "\032l\277\370\2429\216\236\351[{\{\262\350\274\376".dup
     str.force_encoding('BINARY') if str.respond_to?(:force_encoding)
     assert_equal(["00000000  1a6cbff8 a2398e9e e95b7b7b b2e8bcfe   .l...9...[{{...."], HexDump.encode(str))
   end

--- a/test/test_http-access2.rb
+++ b/test/test_http-access2.rb
@@ -34,7 +34,7 @@ class TestClient < Test::Unit::TestCase
 
   def test_agent_name
     @client = HTTPAccess2::Client.new(nil, "agent_name_foo")
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -44,7 +44,7 @@ class TestClient < Test::Unit::TestCase
 
   def test_from
     @client = HTTPAccess2::Client.new(nil, nil, "from_bar")
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -53,7 +53,7 @@ class TestClient < Test::Unit::TestCase
   end
 
   def test_debug_dev
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     assert(str.empty?)
     @client.get(serverurl)
@@ -62,7 +62,7 @@ class TestClient < Test::Unit::TestCase
 
   def _test_protocol_version_http09
     @client.protocol_version = 'HTTP/0.9'
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl + 'hello')
     lines = str.split(/(?:\r?\n)+/)
@@ -76,7 +76,7 @@ class TestClient < Test::Unit::TestCase
 
   def test_protocol_version_http10
     @client.protocol_version = 'HTTP/1.0'
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl + 'hello')
     lines = str.split(/(?:\r?\n)+/)
@@ -88,7 +88,7 @@ class TestClient < Test::Unit::TestCase
   end
 
   def test_protocol_version_http11
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -97,7 +97,7 @@ class TestClient < Test::Unit::TestCase
     assert_equal("GET / HTTP/1.1", lines[3])
     assert_equal("Host: localhost:#{serverport}", lines[7])
     @client.protocol_version = 'HTTP/1.1'
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -105,7 +105,7 @@ class TestClient < Test::Unit::TestCase
     assert_equal("! CONNECTION ESTABLISHED", lines[2])
     assert_equal("GET / HTTP/1.1", lines[3])
     @client.protocol_version = 'HTTP/1.0'
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -314,14 +314,14 @@ class TestClient < Test::Unit::TestCase
   end
 
   def test_extra_headers
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.head(serverurl, nil, {"ABC" => "DEF"})
     lines = str.split(/(?:\r?\n)+/)
     assert_equal("= Request", lines[0])
     assert_match("ABC: DEF", lines[4])
     #
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl, nil, [["ABC", "DEF"], ["ABC", "DEF"]])
     lines = str.split(/(?:\r?\n)+/)

--- a/test/test_httpclient.rb
+++ b/test/test_httpclient.rb
@@ -30,7 +30,7 @@ class TestHTTPClient < Test::Unit::TestCase
 
   def test_agent_name
     @client = HTTPClient.new(nil, "agent_name_foo")
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -40,7 +40,7 @@ class TestHTTPClient < Test::Unit::TestCase
 
   def test_from
     @client = HTTPClient.new(nil, nil, "from_bar")
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -49,7 +49,7 @@ class TestHTTPClient < Test::Unit::TestCase
   end
 
   def test_debug_dev
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     assert_equal(str.object_id, @client.debug_dev.object_id)
     assert(str.empty?)
@@ -58,7 +58,7 @@ class TestHTTPClient < Test::Unit::TestCase
   end
 
   def test_debug_dev_stream
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     conn = @client.get_async(serverurl)
     Thread.pass while !conn.finished?
@@ -67,7 +67,7 @@ class TestHTTPClient < Test::Unit::TestCase
 
   def test_protocol_version_http09
     @client.protocol_version = 'HTTP/0.9'
-    @client.debug_dev = str = ''
+    @client.debug_dev = str = ''.dup
     @client.test_loopback_http_response << "hello\nworld\n"
     res = @client.get(serverurl + 'hello')
     assert_equal('0.9', res.http_version)
@@ -88,7 +88,7 @@ class TestHTTPClient < Test::Unit::TestCase
     assert_equal(nil, @client.protocol_version)
     @client.protocol_version = 'HTTP/1.0'
     assert_equal('HTTP/1.0', @client.protocol_version)
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl + 'hello')
     lines = str.split(/(?:\r?\n)+/)
@@ -100,7 +100,7 @@ class TestHTTPClient < Test::Unit::TestCase
   end
 
   def test_header_accept_by_default
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -108,7 +108,7 @@ class TestHTTPClient < Test::Unit::TestCase
   end
 
   def test_header_accept
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl, :header => {:Accept => 'text/html'})
     lines = str.split(/(?:\r?\n)+/)
@@ -116,7 +116,7 @@ class TestHTTPClient < Test::Unit::TestCase
   end
 
   def test_header_symbol
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.post(serverurl + 'servlet', :header => {:'Content-Type' => 'application/json'}, :body => 'hello')
     lines = str.split(/(?:\r?\n)+/).grep(/^Content-Type/)
@@ -124,7 +124,7 @@ class TestHTTPClient < Test::Unit::TestCase
   end
 
   def test_host_given
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -134,7 +134,7 @@ class TestHTTPClient < Test::Unit::TestCase
     assert_equal("Host: localhost:#{serverport}", lines[7])
     #
     @client.reset_all
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl, nil, {'Host' => 'foo'})
     lines = str.split(/(?:\r?\n)+/)
@@ -166,7 +166,7 @@ class TestHTTPClient < Test::Unit::TestCase
 
   def test_protocol_version_http11
     assert_equal(nil, @client.protocol_version)
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -176,7 +176,7 @@ class TestHTTPClient < Test::Unit::TestCase
     assert_equal("Host: localhost:#{serverport}", lines[7])
     @client.protocol_version = 'HTTP/1.1'
     assert_equal('HTTP/1.1', @client.protocol_version)
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -184,7 +184,7 @@ class TestHTTPClient < Test::Unit::TestCase
     assert_equal("! CONNECTION ESTABLISHED", lines[2])
     assert_equal("GET / HTTP/1.1", lines[3])
     @client.protocol_version = 'HTTP/1.0'
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl)
     lines = str.split(/(?:\r?\n)+/)
@@ -216,7 +216,7 @@ class TestHTTPClient < Test::Unit::TestCase
       #
       @proxyio.string = ""
       @client.proxy = proxyurl
-      @client.debug_dev = str = ""
+      @client.debug_dev = str = "".dup
       assert_equal(200, @client.head(serverurl).status)
       assert(/accept/ =~ @proxyio.string)
       assert(/Host: localhost:#{serverport}/ =~ str)
@@ -225,13 +225,13 @@ class TestHTTPClient < Test::Unit::TestCase
 
   def test_host_header
     @client.proxy = proxyurl
-    @client.debug_dev = str = ""
+    @client.debug_dev = str = "".dup
     @client.test_loopback_http_response << "HTTP/1.0 200 OK\r\n\r\n"
     assert_equal(200, @client.head('http://www.example.com/foo').status)
     # ensure no ':80' is added.  some servers dislike that.
     assert(/\r\nHost: www\.example\.com\r\n/ =~ str)
     #
-    @client.debug_dev = str = ""
+    @client.debug_dev = str = "".dup
     @client.test_loopback_http_response << "HTTP/1.0 200 OK\r\n\r\n"
     assert_equal(200, @client.head('http://www.example.com:12345/foo').status)
     # ensure ':12345' exists.
@@ -323,28 +323,28 @@ class TestHTTPClient < Test::Unit::TestCase
   end
 
   def test_no_proxy_with_initial_dot
-    @client.debug_dev = str = ""
+    @client.debug_dev = str = "".dup
     @client.test_loopback_http_response << "HTTP/1.0 200 OK\r\n\r\n"
     @client.no_proxy = ''
     @client.proxy = proxyurl
     @client.head('http://www.foo.com')
     assert(/CONNECT TO localhost/ =~ str, 'via proxy')
     #
-    @client.debug_dev = str = ""
+    @client.debug_dev = str = "".dup
     @client.test_loopback_http_response << "HTTP/1.0 200 OK\r\n\r\n"
     @client.no_proxy = '.foo.com'
     @client.proxy = proxyurl
     @client.head('http://www.foo.com')
     assert(/CONNECT TO www.foo.com/ =~ str, 'no proxy because .foo.com matches with www.foo.com')
     #
-    @client.debug_dev = str = ""
+    @client.debug_dev = str = "".dup
     @client.test_loopback_http_response << "HTTP/1.0 200 OK\r\n\r\n"
     @client.no_proxy = '.foo.com'
     @client.proxy = proxyurl
     @client.head('http://foo.com')
     assert(/CONNECT TO localhost/ =~ str, 'via proxy because .foo.com does not matche with foo.com')
     #
-    @client.debug_dev = str = ""
+    @client.debug_dev = str = "".dup
     @client.test_loopback_http_response << "HTTP/1.0 200 OK\r\n\r\n"
     @client.no_proxy = 'foo.com'
     @client.proxy = proxyurl
@@ -370,7 +370,7 @@ Connection: close\r
 \r
 hello
 EOS
-      @client.debug_dev = str = ''
+      @client.debug_dev = str = ''.dup
       @client.set_auth("http://www.example.org/baz/", 'admin', 'admin')
       assert_equal('hello', @client.get('http://www.example.org/baz/foo').content)
       assert_match(/^Cookie: foo=bar/, str)
@@ -411,7 +411,7 @@ EOS
     assert_equal('message body 1', @client.get_content('http://somewhere'))
     assert_equal('message body 2', @client.get_content('http://somewhere'))
     #
-    @client.debug_dev = str = ''
+    @client.debug_dev = str = ''.dup
     @client.test_loopback_response << 'message body 3'
     assert_equal('message body 3', @client.get_content('http://somewhere'))
     assert_match(/message body 3/, str)
@@ -597,9 +597,9 @@ EOS
     assert(called)
   end
 
-  GZIP_CONTENT = "\x1f\x8b\x08\x00\x1a\x96\xe0\x4c\x00\x03\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00"
-  DEFLATE_CONTENT = "\x78\x9c\xcb\x48\xcd\xc9\xc9\x07\x00\x06\x2c\x02\x15"
-  DEFLATE_NOHEADER_CONTENT = "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15"
+  GZIP_CONTENT = "\x1f\x8b\x08\x00\x1a\x96\xe0\x4c\x00\x03\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00".dup
+  DEFLATE_CONTENT = "\x78\x9c\xcb\x48\xcd\xc9\xc9\x07\x00\x06\x2c\x02\x15".dup
+  DEFLATE_NOHEADER_CONTENT = "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15".dup
   [GZIP_CONTENT, DEFLATE_CONTENT, DEFLATE_NOHEADER_CONTENT].each do |content|
     content.force_encoding('BINARY') if content.respond_to?(:force_encoding)
   end
@@ -867,7 +867,7 @@ EOS
   end
 
   def test_post_empty
-    @client.debug_dev = str = ''
+    @client.debug_dev = str = ''.dup
     # nil body means 'no content' that is allowed but WEBrick cannot handle it.
     @client.post(serverurl + 'servlet', :body => nil)
     # request does not have 'Content-Type'
@@ -1092,7 +1092,7 @@ EOS
   def test_patch
     assert_equal("patch", @client.patch(serverurl + 'servlet', '').content)
     param = {'1'=>'2', '3'=>'4'}
-    @client.debug_dev = str = ''
+    @client.debug_dev = str = ''.dup
     res = @client.patch(serverurl + 'servlet', param)
     assert_equal(param, params(res.header["x-query"][0]))
     assert_equal('Content-Type: application/x-www-form-urlencoded', str.split(/\r?\n/)[5])
@@ -1122,7 +1122,7 @@ EOS
   def test_put
     assert_equal("put", @client.put(serverurl + 'servlet', '').content)
     param = {'1'=>'2', '3'=>'4'}
-    @client.debug_dev = str = ''
+    @client.debug_dev = str = ''.dup
     res = @client.put(serverurl + 'servlet', param)
     assert_equal(param, params(res.header["x-query"][0]))
     assert_equal('Content-Type: application/x-www-form-urlencoded', str.split(/\r?\n/)[5])
@@ -1169,7 +1169,7 @@ EOS
   # Not prohibited by spec, but normally it's ignored
   def test_delete_with_body
     param = {'1'=>'2', '3'=>'4'}
-    @client.debug_dev = str = ''
+    @client.debug_dev = str = ''.dup
     assert_equal("delete", @client.delete(serverurl + 'servlet', param).content)
     assert_equal({'1' => ['2'], '3' => ['4']}, HTTP::Message.parse(str.split(/\r?\n\r?\n/)[2]))
   end
@@ -1309,14 +1309,14 @@ EOS
   end
 
   def test_extra_headers
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.head(serverurl, nil, {"ABC" => "DEF"})
     lines = str.split(/(?:\r?\n)+/)
     assert_equal("= Request", lines[0])
     assert_match("ABC: DEF", lines[4])
     #
-    str = ""
+    str = "".dup
     @client.debug_dev = str
     @client.get(serverurl, nil, [["ABC", "DEF"], ["ABC", "DEF"]])
     lines = str.split(/(?:\r?\n)+/)
@@ -1326,7 +1326,7 @@ EOS
   end
 
   def test_http_custom_date_header
-    @client.debug_dev = (str = "")
+    @client.debug_dev = (str = "".dup)
     _res = @client.get(serverurl + 'hello', :header => {'Date' => 'foo'})
     lines = str.split(/(?:\r?\n)+/)
     assert_equal('Date: foo', lines[4])
@@ -1870,7 +1870,7 @@ EOS
 
   if RUBY_VERSION >= "1.9.3"
     def test_continue
-      @client.debug_dev = str = ''
+      @client.debug_dev = str = ''.dup
       res = @client.get(serverurl + 'continue', :header => {:Expect => '100-continue'})
       assert_equal(200, res.status)
       assert_equal('done!', res.body)

--- a/test/test_ssl.rb
+++ b/test/test_ssl.rb
@@ -31,7 +31,7 @@ class TestSSL < Test::Unit::TestCase
       @client.ssl_config.set_client_cert_file(path('client.cert'), path('client.key'))
       @client.ssl_config.add_trust_ca(path('ca.cert'))
       @client.ssl_config.add_trust_ca(path('subca.cert'))
-      @client.debug_dev = str = ""
+      @client.debug_dev = str = "".dup
       assert_equal(200, @client.get(@url).status)
       assert(/accept/ =~ @proxyio.string, 'proxy is not used')
       assert(/Host: localhost:#{serverport}/ =~ str)
@@ -70,7 +70,7 @@ unless defined?(HTTPClient::JRubySSLSocket)
 end
 
   def test_debug_dev
-    str = @client.debug_dev = ''
+    str = @client.debug_dev = ''.dup
     cfg = @client.ssl_config
     cfg.client_cert = path("client.cert")
     cfg.client_key = path("client.key")


### PR DESCRIPTION
Also fix some of the tests to work with frozen strings. There are still more errors, including https://github.com/sparklemotion/http-cookie/pull/25.

Closes #395