### PR TITLE
Fix CA configuration by SSL_CERT_DIR

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -1076,6 +1076,9 @@ private
     else
       self.proxy = getenv('http_proxy')
     end
+    if getenv('SSL_CERT_DIR')
+      self.ssl_config.add_trust_ca(getenv('SSL_CERT_DIR'))
+    end
     # no_proxy
     self.no_proxy = getenv('no_proxy')
   end


### PR DESCRIPTION
The environment variable `SSL_CERT_DIR` is documented to configure an
alternative trust CA.

This expected behavior is documented in the SSLConfig module [here](https://github.com/nahi/httpclient/tree/27fbb07685930d1c8dbdc8dd1e72027f79879bbe/lib/httpclient/ssl_config.rb#L187-L190). It doesn't take effect, though. When searching the library's code for `SSL_CERT_DIR` it doesn't occur. 

This setting is important in cases when a user wants to use a debug proxy, the connection is encrypted, and the client code doesn't use `httpclient` directly, but through third-party API SDKs, e.g. the `google-cloud-storage` gem.

Fixes #369