### PR TITLE
Drop EOL rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 sudo: false
 
 rvm:
-  - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
-  - 2.4.0
-  - 2.5.0
-  - 2.6.0
+  - 2.3.8
+  - 2.4.4
+  - 2.5.3
+  - 2.6.1
   - ruby-head
-  - jruby-19mode
   - jruby-head
 
 script: "bundle exec rake --trace"
@@ -17,7 +13,3 @@ script: "bundle exec rake --trace"
 notifications:
   recipients:
     - nahi@ruby-lang.org
-
-matrix:
-  allow_failures:
-    - rvm: jruby-head


### PR DESCRIPTION
Also updated to the latest teeny versions.

No plan to actively drop old version support. It is for reducing Travis
run time.