### PR TITLE
Travis: Add ruby-head to allow_failures; drop unused directive sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+language: ruby
 
 rvm:
   - 2.3.8
@@ -9,6 +9,10 @@ rvm:
   - jruby-head
 
 script: "bundle exec rake --trace"
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 
 notifications:
   recipients:


### PR DESCRIPTION
This PR

- adds `language: ruby`
- removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).
- places ruby-head in `allow_failures` (like nurse said in #407)