### PR TITLE
test/test_jsonclient: Avoid unused variable Ruby warning

### DIFF
--- a/test/test_jsonclient.rb
+++ b/test/test_jsonclient.rb
@@ -62,13 +62,13 @@ class TestJSONClient < Test::Unit::TestCase
 
   def test_hash_header_not_modified
     header = {'X-foo' => 'bar'}
-    res = @client.post(serverurl, :header => header, :body => {'a' => 1, 'b' => {'c' => 2}})
+    _res = @client.post(serverurl, :header => header, :body => {'a' => 1, 'b' => {'c' => 2}})
     assert_equal({'X-foo' => 'bar'}, header)
   end
 
   def test_array_header_not_modified
     header = [['X-foo', 'bar']]
-    res = @client.post(serverurl, :header => header, :body => {'a' => 1, 'b' => {'c' => 2}})
+    _res = @client.post(serverurl, :header => header, :body => {'a' => 1, 'b' => {'c' => 2}})
     assert_equal([['X-foo', 'bar']], header)
   end
 


### PR DESCRIPTION
This PR avoids a Ruby warning emitted when running the test suite:

> /home/travis/build/nahi/httpclient/test/test_jsonclient.rb:65: warning: assigned but unused variable - res
> /home/travis/build/nahi/httpclient/test/test_jsonclient.rb:71: warning: assigned but unused variable - res

Hope this helps!