### PR TITLE
Use system roots rather than outdated bundled certs

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -450,6 +450,7 @@ class HTTPClient
     self.proxy = proxy if proxy
     keep_webmock_compat
     instance_eval(&block) if block
+    @session_manager&.ssl_config&.set_default_paths
   end
 
   # webmock 1.6.2 depends on HTTP::Message#body.content to work.


### PR DESCRIPTION
Apply a patch to work around outdated bundled certs, credit: https://twitter.com/jordanhollinger/status/1443608013902958598?s=21 and the team at LiveLink. 

Also https://github.com/nahi/httpclient/issues/445