### PR TITLE
Use `stat` instead of `lstat` to find file size

### DIFF
--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -618,8 +618,8 @@ module HTTP
           if Message.file?(part)
             @as_stream = true
             @body << part
-            if part.respond_to?(:lstat)
-              sz = part.lstat.size
+            if part.respond_to?(:stat)
+              sz = part.stat.size
               add_size(part, sz)
             elsif part.respond_to?(:size)
               if sz = part.size


### PR DESCRIPTION
If the selected file is a symlink, `lstat.size` returns the symlink size in Linux and 0 in Windows, causing a truncated file to be sent. Use `stat.size` instead.