### PR TITLE
Share dotless-domain cookies with subdomains

### DIFF
--- a/lib/httpclient/webagent-cookie.rb
+++ b/lib/httpclient/webagent-cookie.rb
@@ -44,7 +44,7 @@ class WebAgent
         # allows; host == rubyforge.org, domain == .rubyforge.org
         return tail_match?(domainname, '.' + hostname)
       else
-        return (hostname == domainname)
+        return (hostname == domainname) || tail_match?(domainname, '.' + hostname)
       end
     end
   end


### PR DESCRIPTION
I was testing a single-signon login which delegated one-time password challenge/verification to a microservice at a subdomain (specifically using the CoxAuto menagerie of servers).  This was failing, and I isolated the problem to a redirect that was issued to a service at a subdomain. The problem is that the main cookie was:
```
#<WebAgent::Cookie:0x000000010897d6b0
 @discard=true,
 @domain="signin.coxautoinc.com",
 @domain_orig="signin.coxautoinc.com",
 @expires=nil,
 @http_only=true,
 @name="bridge-device-token",
 @override=nil,
 @path="/",
 @path_orig="/",
 @secure=true,
 @url=#<Addressable::URI:0x1f7c URI:https://xtime.signin.coxautoinc.com/signin/factors/verify>,
 @use=true,
 @value="...deleted...">
```
It must be shared between `signin.coxautoinc.com` and `xtime.signin.coxautoinc.com`.  However, the server did not provide the dot-prefix which was required by `httpclient`. As I understand it, this is now an obsolete requirement:

[4.1.2.3.](https://httpwg.org/specs/rfc6265.html#rfc.section.4.1.2.3) [The Domain Attribute](https://httpwg.org/specs/rfc6265.html#sane-domain)
_The Domain attribute specifies those hosts to which the cookie will be sent. For example, if the value of the Domain attribute is "example.com", the user agent will include the cookie in the Cookie header when making HTTP requests to example.com, www.example.com, and www.corp.example.com. (Note that a leading %x2E ("."), if present, is ignored even though that character is not permitted, but a trailing %x2E ("."), if present, will cause the user agent to ignore the attribute.)_