### PR TITLE
Add dependency to `webrick` and `mutex_m` for Ruby 3.0 and Ruby 3.4

### DIFF
--- a/httpclient.gemspec
+++ b/httpclient.gemspec
@@ -11,4 +11,6 @@ Gem::Specification.new { |s|
   s.require_paths = ['lib']
   s.files = Dir.glob('{bin,lib,sample,test}/**/*') + ['README.md']
   s.license = 'ruby'
+  s.add_dependency "mutex_m"
+  s.add_dependency "webrick"
 }


### PR DESCRIPTION
This pull request adds dependency to `webrick` and `mutex_m` for Ruby 3.0 and Ruby 3.4.

- `webrick` has been bundled gem since Ruby 3.0 https://bugs.ruby-lang.org/issues/17303
- `mutex_m` will be bundled gem since Ruby 3.4 https://bugs.ruby-lang.org/issues/19351

Ruby on Rails CI is getting failed https://buildkite.com/rails/rails-nightly/builds/37#018d001f-66ce-4611-806a-531c1c8a5afb because
`httpclient` gem is required by the `webmock` and Rails (Action Mailbox) requires `webmock` gem.

https://rubygems.org/gems/httpclient/reverse_dependencies https://github.com/rails/rails/blob/4fb230d2140054f8d0114c2c8dcc659af10a7972/Gemfile#L128

- Ruby version tested
```
$ ruby -v
ruby 3.4.0dev (2024-01-13T02:08:03Z master 573bfb3a14) +MN [x86_64-linux]
```

- No dependency added
```
$ bundle exec rake test
lib/httpclient/version.rb:2: warning: already initialized constant HTTPClient::VERSION
/home/yahonda/src/github.com/nahi/httpclient/lib/httpclient/version.rb:2: warning: previous definition of VERSION was here
/home/yahonda/.rbenv/versions/trunk/bin/ruby -w -I"lib:lib" /home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb "test/test_auth.rb" "test/test_cookie.rb" "test/test_hexdump.rb" "test/test_http-access2.rb" "test/test_httpclient.rb" "test/test_include_client.rb" "test/test_jsonclient.rb" "test/test_ssl.rb" "test/test_webagent-cookie.rb"
/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/simplecov-rcov-0.3.3/lib/simplecov-rcov.rb:25: warning: assigned but unused variable - generated_on
/home/yahonda/src/github.com/nahi/httpclient/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but is not part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec.
Coverage report Rcov style generated for Unit Tests to /home/yahonda/src/github.com/nahi/httpclient/coverage/rcov
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
/home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require': cannot load such file -- mutex_m (LoadError)
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/src/github.com/nahi/httpclient/lib/httpclient/auth.rb:11:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/src/github.com/nahi/httpclient/lib/httpclient.rb:19:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/src/github.com/nahi/httpclient/test/helper.rb:11:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/src/github.com/nahi/httpclient/test/test_auth.rb:1:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `select'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1): [ruby -w -I"lib:lib" /home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb "test/test_auth.rb" "test/test_cookie.rb" "test/test_hexdump.rb" "test/test_http-access2.rb" "test/test_httpclient.rb" "test/test_include_client.rb" "test/test_jsonclient.rb" "test/test_ssl.rb" "test/test_webagent-cookie.rb" ]
/home/yahonda/.rbenv/versions/trunk/bin/bundle:25:in `load'
/home/yahonda/.rbenv/versions/trunk/bin/bundle:25:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
$
```

- Only when `s.add_dependency "mutex_m"` is added
```
$ bundle exec rake test
lib/httpclient/version.rb:2: warning: already initialized constant HTTPClient::VERSION
/home/yahonda/src/github.com/nahi/httpclient/lib/httpclient/version.rb:2: warning: previous definition of VERSION was here
/home/yahonda/.rbenv/versions/trunk/bin/ruby -w -I"lib:lib" /home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb "test/test_auth.rb" "test/test_cookie.rb" "test/test_hexdump.rb" "test/test_http-access2.rb" "test/test_httpclient.rb" "test/test_include_client.rb" "test/test_jsonclient.rb" "test/test_ssl.rb" "test/test_webagent-cookie.rb"
/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/simplecov-rcov-0.3.3/lib/simplecov-rcov.rb:25: warning: assigned but unused variable - generated_on
/home/yahonda/src/github.com/nahi/httpclient/test/helper.rb:12: warning: webrick was loaded from the standard library, but is not part of the default gems since Ruby 3.0.0. Add webrick to your Gemfile or gemspec.
Coverage report Rcov style generated for Unit Tests to /home/yahonda/src/github.com/nahi/httpclient/coverage/rcov
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
/home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require': cannot load such file -- webrick (LoadError)
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/src/github.com/nahi/httpclient/test/helper.rb:12:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/src/github.com/nahi/httpclient/test/test_auth.rb:1:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `select'
	from /home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1): [ruby -w -I"lib:lib" /home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb "test/test_auth.rb" "test/test_cookie.rb" "test/test_hexdump.rb" "test/test_http-access2.rb" "test/test_httpclient.rb" "test/test_include_client.rb" "test/test_jsonclient.rb" "test/test_ssl.rb" "test/test_webagent-cookie.rb" ]
/home/yahonda/.rbenv/versions/trunk/bin/bundle:25:in `load'
/home/yahonda/.rbenv/versions/trunk/bin/bundle:25:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
$
```