### PR TITLE
Add GitHub Actions to run CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: test
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'head']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Run tests
+      run: bundle exec rake --trace

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ group :development do
   gem 'rake', :require => false
   gem 'rdoc'
   gem 'test-unit'
-  gem 'simplecov'
-  gem 'simplecov-rcov'
   gem 'pry'
   gem 'rack', '~> 2.2'
   gem 'rubysspi'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,11 +1,4 @@
 # -*- encoding: utf-8 -*-
-begin
-  require 'simplecov'
-  require 'simplecov-rcov'
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start
-rescue LoadError
-end
 require 'test/unit'
 
 require 'httpclient'


### PR DESCRIPTION
This pull request adds GitHub Actions to run CI.

* CRuby versions tested are based on the Travis CI setting.
https://github.com/nahi/httpclient/blob/master/.travis.yml

* JRuby and TruffleRuby have not been added yet until all CI against CRuby are green

#### TODO to address failures/errors

- [x] Ruby 2.5 raises `simplecov-rcov` and `erb` raises `no implicit conversion of Hash into Integer (TypeError)` by removing simplecov and simpleconv-rcov tentatively workaround this error via https://github.com/nahi/httpclient/pull/456/commits/c06d1e8adf85fc9566c1a70f0c3e82567590b779
- [ ] Ruby 3.1 and higher raises OpenSSL related errors
- [x] Ruby 3.4.0 dev needs to add base64 gem because it is a bundled gem since Ruby 3.4, that will be taken care of by adding it to rubyntlm via https://github.com/WinRb/rubyntlm/pull/62

I need any help to take care of these failures/errors above.