### PR TITLE
Fix frozen string error in Ruby 3.4.0-preview1

### DIFF
--- a/lib/httpclient/util.rb
+++ b/lib/httpclient/util.rb
@@ -64,7 +64,7 @@ class HTTPClient
         # Overwrites the original definition just for one line...
         def authority
           self.host && @authority ||= (begin
-            authority = ""
+            authority = +""
             if self.userinfo != nil
               authority << "#{self.userinfo}@"
             end


### PR DESCRIPTION
This change fixed a frozen string error with the `--enable-frozen-string-literal` in Ruby 3.4.0-preview1.
See the reproduction below (note that the Addressable gem is needed):

```sh-session
$ bundle install
...
$ bundle add addressable
...
$ RUBYOPT='--enable-frozen-string-literal -I lib -r httpclient' bundle exec ruby -e 'p HTTPClient'
/work/lib/httpclient/util.rb:71:in 'HTTPClient::Util::AddressableURI#authority': can't modify frozen String: "" (FrozenError)
	from /usr/local/bundle/gems/addressable-2.8.6/lib/addressable/uri.rb:2350:in 'Addressable::URI#to_s'
	from /usr/local/bundle/gems/addressable-2.8.6/lib/addressable/uri.rb:863:in 'Addressable::URI#initialize'
	from /usr/local/bundle/gems/addressable-2.8.6/lib/addressable/uri.rb:165:in 'Class#new'
	from /usr/local/bundle/gems/addressable-2.8.6/lib/addressable/uri.rb:165:in 'Addressable::URI.parse'
	from /work/lib/httpclient/util.rb:154:in 'HTTPClient::Util.urify'
	from /work/lib/httpclient/http.rb:195:in '<class:Headers>'
	from /work/lib/httpclient/http.rb:104:in '<class:Message>'
	from /work/lib/httpclient/http.rb:98:in '<module:HTTP>'
	from /work/lib/httpclient/http.rb:19:in '<top (required)>'
	from <internal:/usr/local/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
	from <internal:/usr/local/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
	from /work/lib/httpclient/session.rb:23:in '<top (required)>'
	from <internal:/usr/local/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
	from <internal:/usr/local/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
	from /work/lib/httpclient.rb:17:in '<top (required)>'
	from <internal:/usr/local/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
	from <internal:/usr/local/lib/ruby/3.4.0+0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
```

Ref https://www.ruby-lang.org/en/news/2024/05/16/ruby-3-4-0-preview1-released/
