### PR TITLE
Address `warning: literal string will be frozen in the future` warnings

### DIFF
--- a/lib/httpclient.rb
+++ b/lib/httpclient.rb
@@ -1240,7 +1240,7 @@ private
       conn.push(res)
       return res
     end
-    content = block ? nil : ''
+    content = block ? nil : ''.dup
     res = HTTP::Message.new_response(content, req.header)
     @debug_dev << "= Request\n\n" if @debug_dev
     sess = @session_manager.query(req, proxy)

--- a/lib/httpclient/http.rb
+++ b/lib/httpclient/http.rb
@@ -574,7 +574,7 @@ module HTTP
       end
 
       def dump_file(io, dev, sz)
-        buf = ''
+        buf = ''.dup
         rest = sz
         while rest > 0
           n = io.read([rest, @chunk_size].min, buf)

--- a/lib/httpclient/session.rb
+++ b/lib/httpclient/session.rb
@@ -950,7 +950,7 @@ class HTTPClient
     end
 
     def empty_bin_str
-      str = ''
+      str = ''.dup
       str.force_encoding('BINARY') if str.respond_to?(:force_encoding)
       str
     end

--- a/lib/httpclient/util.rb
+++ b/lib/httpclient/util.rb
@@ -64,7 +64,7 @@ class HTTPClient
         # Overwrites the original definition just for one line...
         def authority
           self.host && @authority ||= (begin
-            authority = ""
+            authority = "".dup
             if self.userinfo != nil
               authority << "#{self.userinfo}@"
             end


### PR DESCRIPTION
This commit addresses the `warning: literal string will be frozen in the future` warnings appeared at Rails CI https://buildkite.com/rails/rails-nightly/builds/1122#019263a3-2200-4e62-a6a8-028cffa60aaf

Here are the warnings appeared:
```ruby
/usr/local/lib/ruby/gems/3.4.0+0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient.rb:1256: warning: literal string will be frozen in the future
/usr/local/lib/ruby/gems/3.4.0+0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/http.rb:580: warning: literal string will be frozen in the future
/usr/local/lib/ruby/gems/3.4.0+0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/session.rb:954: warning: literal string will be frozen in the future
/usr/local/lib/ruby/gems/3.4.0+0/bundler/gems/httpclient-d57cc6d5ffee/lib/httpclient/util.rb:71: warning: literal string will be frozen in the future
```

There should be some warnings remained because Rails CI does not use all of httpclient code. I'll open some pull requests later to address remaining ones.

Ref: https://bugs.ruby-lang.org/issues/20205