### PR TITLE
Make webrick a dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development do
   gem 'rack-ntlm-test-service'
   gem 'logger'
   gem 'ostruct' # For rack-2.2.11/lib/rack/show_exceptions.rb
+  gem 'webrick'
 end
 
 gemspec

--- a/httpclient.gemspec
+++ b/httpclient.gemspec
@@ -12,5 +12,4 @@ Gem::Specification.new { |s|
   s.files = Dir.glob('{bin,lib,sample,test}/**/*') + ['README.md']
   s.license = 'ruby'
   s.add_dependency "mutex_m"
-  s.add_dependency "webrick"
 }


### PR DESCRIPTION
It's not actually needed at runtime, it's only used by the test suite.

cc @takkanm 