### PR TITLE
Update license for version 2.8.3

### DIFF
--- a/httpclient.gemspec
+++ b/httpclient.gemspec
@@ -10,5 +10,5 @@ Gem::Specification.new { |s|
   s.summary = 'gives something like the functionality of libwww-perl (LWP) in Ruby'
   s.require_paths = ['lib']
   s.files = Dir.glob('{bin,lib,sample,test}/**/*') + ['README.md']
-  s.license = 'ruby'
+  s.license = 'Ruby'
 }


### PR DESCRIPTION
License should be `Ruby` instead of `ruby` according to https://spdx.org/licenses/.